### PR TITLE
Framework for mesolve and odeint

### DIFF
--- a/torchqdynamics/__init__.py
+++ b/torchqdynamics/__init__.py
@@ -3,4 +3,3 @@ from .qtensor import QTensor
 from .mesolve import mesolve
 from .ssolve import ssolve
 from .smesolve import smesolve
-from .solvers import *

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -5,7 +5,7 @@ from .solver import Rouchon
 
 
 def mesolve(
-    H, jump_ops, rho0, tsave, solver=None, sensitivity='autograd', variables=None
+    H, jump_ops, rho0, tsave, solver=None, sensitivity='autograd', parameters=None
 ):
     if solver is None:
         # TODO: The default dt should not be choosen in such an arbitrary
@@ -22,7 +22,7 @@ def mesolve(
         raise NotImplementedError
 
     # compute the result
-    return odeint(qsolver, rho0, tsave, sensitivity=sensitivity, variables=variables)
+    return odeint(qsolver, rho0, tsave, sensitivity=sensitivity, parameters=parameters)
 
 
 class QSolver:

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -66,21 +66,7 @@ class MERouchon1(MERouchon):
 
 class MERouchon2(MERouchon):
     def forward(self, t, dt, rho):
-        """Compute rho(t+dt) using a Rouchon method of order 2."""
-        # non-hermitian Hamiltonian at time t
-        H_nh = self.H(t) - 0.5j * self.sum_nojump
-
-        # build time-dependent Kraus operators
-        # TODO: Add the missing time derivative term in -0.5j * dt**2 * \dot{H}
-        M0 = self.I - 1j * dt * H_nh - 0.5 * dt**2 * H_nh @ H_nh
-        M1s = 0.5 * self.Ls @ M0
-        M1s += M1s.adjoint()
-
-        # compute rho(t+dt)
-        drho_ = dt * (M1s @ rho.unsqueeze(0) @ M1s.adjoint()).sum(dim=0)
-        drho = M0 @ rho @ M0.adjoint() + drho_
-        drho += 0.5 * dt * (M1s @ drho_.unsqueeze(0) @ M1s.adjoint()).sum(dim=0)
-        return drho
+        raise NotImplementedError
 
     def forward_adjoint(self, t, dt, phi):
         raise NotImplementedError

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -10,7 +10,8 @@ from .odeint import odeint
 
 
 def mesolve(
-    H, jump_ops, rho0, tsave, solver, sensitivity='autograd', model_params=None
+    H, jump_ops, rho0, tsave, solver=Rouchon(), sensitivity='autograd',
+    model_params=None
 ):
     # Define the QSolver
     if isinstance(solver, Rouchon):
@@ -97,5 +98,6 @@ class MERouchon2(MERouchon):
 
 @dataclass
 class Rouchon:
-    dt: float
+    dt: float = 1e-2
+    order: int = 1
     stepclass: str = 'fixed'

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -56,8 +56,10 @@ class MERouchon1(MERouchon):
         M0 = self.I - 1j * dt * H_nh
 
         # compute rho(t+dt)
-        rho = M0 @ rho @ M0.adjoint()
-        rho += dt * (self.jump_ops @ rho.unsqueeze(0) @ self.jumpdag_ops).sum(dim=0)
+        rho = (
+            M0 @ rho @ M0.adjoint() + dt *
+            (self.jump_ops @ rho.unsqueeze(0) @ self.jumpdag_ops).sum(dim=0)
+        )
         rho = rho / rho.trace()
         return rho
 

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -29,6 +29,12 @@ class QSolver:
     def __init__(self):
         pass
 
+    def forward(self, t, dt, rho):
+        pass
+
+    def forward_adjoint(self, t, dt, phi):
+        pass
+
 
 class MERouchon(QSolver):
     def __init__(self, H, jump_ops, solver_options):

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -80,7 +80,7 @@ class MERouchon2(MERouchon):
 
         # Compute rho(t+dt)
         drho_ = dt * torch.sum(M1s @ rho.unsqueeze(0) @ M1s.adjoint(), dim=0)
-        drho += 0.5 * dt * torch.sum(M1s @ drho_.unsqueeze(0) @ M1s.adjoint(), dim=0)
+        drho = 0.5 * dt * torch.sum(M1s @ drho_.unsqueeze(0) @ M1s.adjoint(), dim=0)
         drho += drho_ + M0 @ rho @ M0.adjoint()
 
         return drho

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -1,14 +1,17 @@
-from dataclasses import dataclass
-
 import torch
 
 from .odeint import odeint
+from .solver import Rouchon
 
 
 def mesolve(
-    H, jump_ops, rho0, tsave, solver=Rouchon(), sensitivity='autograd',
-    model_params=None
+    H, jump_ops, rho0, tsave, solver=None, sensitivity='autograd', model_params=None
 ):
+    if solver is None:
+        # TODO: The default dt should not be choosen in such an arbitrary
+        # fashion, which depends on the time unit used by the user.
+        solver = Rouchon(dt=1e-2)
+
     # define the QSolver
     if isinstance(solver, Rouchon):
         if solver.order == 1:
@@ -77,17 +80,3 @@ class MERouchon2(MERouchon):
 
     def forward_adjoint(self, t, dt, phi):
         raise NotImplementedError
-
-
-# --------------------------------------------------------------------------------------
-#     ME Solver Options
-# --------------------------------------------------------------------------------------
-
-# See the PR by @abocquet at https://github.com/PierreGuilmin/torchqdynamics/pull/10
-
-
-@dataclass
-class Rouchon:
-    dt: float = 1e-2
-    order: float = 1
-    stepclass: str = 'fixed'

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -58,6 +58,7 @@ class MERouchon1(MERouchon):
         # compute rho(t+dt)
         rho = M0 @ rho @ M0.adjoint()
         rho += dt * (self.jump_ops @ rho.unsqueeze(0) @ self.jumpdag_ops).sum(dim=0)
+        rho = rho / rho.trace()
         return rho
 
     def forward_adjoint(self, t, dt, phi):

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -56,9 +56,9 @@ class MERouchon1(MERouchon):
         M0 = self.I - 1j * dt * H_nh
 
         # compute rho(t+dt)
-        drho = M0 @ rho @ M0.adjoint()
-        drho += dt * (self.jump_ops @ rho.unsqueeze(0) @ self.jumpdag_ops).sum(dim=0)
-        return drho
+        rho = M0 @ rho @ M0.adjoint()
+        rho += dt * (self.jump_ops @ rho.unsqueeze(0) @ self.jumpdag_ops).sum(dim=0)
+        return rho
 
     def forward_adjoint(self, t, dt, phi):
         raise NotImplementedError

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -1,63 +1,101 @@
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
 
-import numpy as np
 import torch
-import torchdiffeq
+
+from .odeint import odeint
+
+# --------------------------------------------------------------------------------------
+#     Main mesolve function
+# --------------------------------------------------------------------------------------
 
 
 def mesolve(
-    H: torch.Tensor,
-    Ls: List[torch.Tensor],
-    rho0: torch.Tensor,
-    tlist: np.ndarray,
-    solver: str = 'rk4',
-    options: Optional[Dict[str, Any]] = None,
-) -> torch.Tensor:
-    if options is None:
-        options = {}
+    H, jump_ops, rho0, tsave, solver, sensitivity='autograd', model_params=None
+):
+    # Define the QSolver
+    if isinstance(solver, Rouchon):
+        if solver.order == 1:
+            qsolver = MERouchon1(H, jump_ops, solver)
+        elif solver.order == 2:
+            qsolver = MERouchon2(H, jump_ops, solver)
+    else:
+        raise NotImplementedError
 
-    if solver == 'rk4':
-        if not 'step_size' in options:
-            options['step_size'] = 0.001
-        return _mesolve_torchdiffeq(H, Ls, rho0, tlist, options)
-
-    raise ValueError('invalid solver (supported: \'rk4\')')
-
-
-def _dissipator(L: torch.tensor, Ldag: torch.tensor, rho: torch.tensor) -> torch.tensor:
-    # [speedup] by using the precomputed jump operator adjoint
-    return L @ rho @ Ldag - 0.5 * Ldag @ L @ rho - 0.5 * rho @ Ldag @ L
+    # Compute the result
+    return odeint(
+        qsolver, rho0, tsave, sensitivity=sensitivity, model_params=model_params
+    )
 
 
-def _lindbladian(
-    H: torch.Tensor,
-    Ls: torch.Tensor,
-    Lsdag: torch.Tensor,
-    rho: torch.Tensor,
-) -> torch.Tensor:
-    # [speedup] by using the precomputed jump operators adjoint
-    return -1j * (H @ rho - rho @ H) + _dissipator(Ls, Lsdag, rho).sum(0)
+# --------------------------------------------------------------------------------------
+#     ME QSolver classes
+# --------------------------------------------------------------------------------------
 
 
-def _mesolve_torchdiffeq(
-    H: torch.Tensor,
-    Ls: List[torch.Tensor],
-    rho0: torch.Tensor,
-    tlist: np.ndarray,
-    options: Dict[str, Any],
-) -> torch.Tensor:
-    Ls = torch.stack(Ls)
-    # [speedup] by precomputing the jump operators adjoint
-    Lsdag = Ls.adjoint().resolve_conj()
+class QSolver:
+    def __init__(self):
+        pass
 
-    def f(t, x):
-        rho = torch.view_as_complex(x)
-        drho = _lindbladian(H, Ls, Lsdag, rho)
-        return torch.view_as_real(drho)
 
-    y0 = torch.view_as_real(rho0)
-    t = torch.from_numpy(tlist)
-    options = {'step_size': options['step_size']}
+class MERouchon(QSolver):
+    def __init__(self, H, jump_ops, solver_options):
+        self.H = H
+        self.jump_ops = jump_ops
+        self.jumpdag_ops = jump_ops.adjoint()
+        self.sum_nojump = (self.jumpdag_ops @ self.jump_ops).sum(dim=0)
+        self.I = torch.eye(H(0).shape[-1]).to(H(0))
+        self.options = solver_options
 
-    ys = torchdiffeq.odeint(f, y0, t, method='rk4', options=options)
-    return torch.view_as_complex(ys)
+
+class MERouchon1(MERouchon):
+    def forward(self, t, dt, rho):
+        """Compute rho(t+dt) using a Rouchon method of order 1"""
+        # Non-hermitian Hamiltonian at time t
+        H_nh = self.H(t) - 0.5j * self.sum_nojump
+
+        # Build time-dependent Kraus operators
+        M0 = self.I - 1j * dt * H_nh
+        M1s = self.jump_ops
+
+        # Compute rho(t+dt)
+        drho = M0 @ rho @ M0.adjoint(
+        ) + dt * (self.jump_ops @ rho.unsqueeze(0) @ self.jumpdag_ops).sum(dim=0)
+
+        return drho
+
+    def forward_adjoint(self, t, dt, phi):
+        raise NotImplementedError
+
+
+class MERouchon2(MERouchon):
+    def forward(self, t, dt, rho):
+        """Compute rho(t+dt) using a Rouchon method of order 2"""
+        # Non-hermitian Hamiltonian at time t
+        H_nh = self.H(t) - 0.5j * self.sum_nojump
+
+        # Build time-dependent Kraus operators
+        M0 = self.I - 1j * dt * H_nh - 0.5 * dt**2 * H_nh**2
+        M1s = 0.5 * (self.Ls @ M0 + M0 @ self.Ls)
+
+        # Compute rho(t+dt)
+        drho_ = dt * torch.sum(M1s @ rho.unsqueeze(0) @ M1s.adjoint(), dim=0)
+        drho += 0.5 * dt * torch.sum(M1s @ drho_.unsqueeze(0) @ M1s.adjoint(), dim=0)
+        drho += drho_ + M0 @ rho @ M0.adjoint()
+
+        return drho
+
+    def forward_adjoint(self, t, dt, phi):
+        raise NotImplementedError
+
+
+# --------------------------------------------------------------------------------------
+#     ME Solver Options
+# --------------------------------------------------------------------------------------
+
+# See the PR by @abocquet at https://github.com/PierreGuilmin/torchqdynamics/pull/10
+
+
+@dataclass
+class Rouchon:
+    dt: float
+    stepclass: str = 'fixed'

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -75,7 +75,8 @@ class MERouchon2(MERouchon):
         H_nh = self.H(t) - 0.5j * self.sum_nojump
 
         # Build time-dependent Kraus operators
-        M0 = self.I - 1j * dt * H_nh - 0.5 * dt**2 * H_nh**2
+        # TODO: Add the missing time derivative term in -0.5j * dt**2 * \dot{H}
+        M0 = self.I - 1j * dt * H_nh - 0.5 * dt**2 * H_nh @ H_nh
         M1s = 0.5 * (self.Ls @ M0 + M0 @ self.Ls)
 
         # Compute rho(t+dt)
@@ -99,5 +100,5 @@ class MERouchon2(MERouchon):
 @dataclass
 class Rouchon:
     dt: float = 1e-2
-    order: int = 1
+    order: float = 1
     stepclass: str = 'fixed'

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -5,7 +5,7 @@ from .solver import Rouchon
 
 
 def mesolve(
-    H, jump_ops, rho0, tsave, solver=None, sensitivity='autograd', model_params=None
+    H, jump_ops, rho0, tsave, solver=None, sensitivity='autograd', variables=None
 ):
     if solver is None:
         # TODO: The default dt should not be choosen in such an arbitrary
@@ -22,9 +22,7 @@ def mesolve(
         raise NotImplementedError
 
     # compute the result
-    return odeint(
-        qsolver, rho0, tsave, sensitivity=sensitivity, model_params=model_params
-    )
+    return odeint(qsolver, rho0, tsave, sensitivity=sensitivity, variables=variables)
 
 
 class QSolver:

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -2,6 +2,8 @@ import warnings
 
 import torch
 
+from .solver import AdaptativeStep, FixedStep
+
 
 def odeint(qsolver, y0, tsave, sensitivity='autograd', model_params=None):
     # check arguments
@@ -19,9 +21,9 @@ def odeint(qsolver, y0, tsave, sensitivity='autograd', model_params=None):
 
 
 def odeint_main(qsolver, y0, tsave):
-    if qsolver.options.stepclass == 'fixed':
+    if isinstance(qsolver.options, FixedStep):
         return _fixed_odeint(qsolver, y0, tsave)
-    elif qsolver.options.stepclass == 'adaptive':
+    elif isinstance(qsolver.options, AdaptativeStep):
         return _adaptive_odeint(qsolver, y0, tsave)
 
 

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -69,11 +69,12 @@ def _fixed_odeint(qsolver, y0, tsave):
 
 
 def check_tsave(tsave):
-    """Check tsave is a sorted 1-D `torch.tensor`."""
-    tsave = torch.tensor(tsave)
-
+    """Check that `tsave` is valid (it must be a non-empty 1D tensor sorted in
+    strictly ascending order and containing only positive values)."""
     if tsave.dim() != 1 or len(tsave) == 0:
         raise ValueError('Argument `tsave` must be a non-empty 1D torch.Tensor.')
     if not torch.all(torch.diff(tsave) > 0):
         raise ValueError('Argument `tsave` must be sorted in strictly ascending order.')
+    if not torch.all(tsave >= 0):
+        raise ValueError('Argument `tsave` must contain positive values only.')
     return tsave

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -56,10 +56,6 @@ def _fixed_odeint(qsolver, y0, tsave):
     # run the ODE routine
     t, y = 0.0, y0
     while t < tsave[-1]:
-        # check if final time is reached
-        if t + dt > tsave[-1]:
-            dt = tsave[-1] - t
-
         # iterate solution
         y = qsolver.forward(t, dt, y)
         t = t + dt

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -49,7 +49,7 @@ def _adaptive_odeint(qsolver, y0, tsave):
 def _fixed_odeint(qsolver, y0, tsave):
     # Initialize save tensor
     ysave = torch.zeros((len(tsave), ) + y0.shape).to(y0)
-    save_counter, save_flag = 0, False
+    save_counter = 0
     if tsave[0] == 0:
         ysave[0] = y0
         save_counter += 1

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -44,9 +44,9 @@ def _adaptive_odeint(qsolver, y0, tsave):
 
 def _fixed_odeint(qsolver, y0, tsave):
     # initialize save tensor
-    ysave = torch.zeros((len(tsave), ) + y0.shape).to(y0)
+    ysave = torch.zeros(len(tsave), *y0.shape).to(y0)
     save_counter = 0
-    if tsave[0] == 0:
+    if tsave[0] == 0.0:
         ysave[0] = y0
         save_counter += 1
 
@@ -54,7 +54,7 @@ def _fixed_odeint(qsolver, y0, tsave):
     dt = qsolver.options.dt
 
     # run the ODE routine
-    t, y = 0, y0
+    t, y = 0.0, y0
     while t < tsave[-1]:
         # check if final time is reached
         if t + dt > tsave[-1]:
@@ -69,18 +69,15 @@ def _fixed_odeint(qsolver, y0, tsave):
             ysave[save_counter] = y
             save_counter += 1
 
-    return tsave, ysave
+    return ysave
 
 
 def check_tsave(tsave):
     """Check tsave is a sorted 1-D `torch.tensor`."""
-    if isinstance(tsave, (list, np.ndarray)):
-        tsave = torch.cat(tsave)
-    if tsave.dim != 1 or len(tsave) == 0:
-        raise ValueError('Argument `tsave` should be a non-empty 1-D torch.Tensor.')
+    tsave = torch.tensor(tsave)
+
+    if tsave.dim() != 1 or len(tsave) == 0:
+        raise ValueError('Argument `tsave` must be a non-empty 1D torch.Tensor.')
     if not torch.all(torch.diff(tsave) > 0):
-        raise ValueError(
-            'Argument `tsave` is not sorted in ascending order '
-            'or contains duplicate values.'
-        )
+        raise ValueError('Argument `tsave` must be sorted in strictly ascending order.')
     return tsave

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -1,0 +1,95 @@
+import warnings
+
+import torch
+
+# --------------------------------------------------------------------------------------
+#     Main odeint function
+# --------------------------------------------------------------------------------------
+
+
+def odeint(qsolver, y0, tsave, sensitivity='autograd', model_params=None):
+    # Check arguments
+    init_tsave(tsave)
+    if (model_params is not None) and (sensitivity in [None, 'autograd']):
+        warnings.warn('Argument `model_params` was supplied in `odeint` but not used.')
+
+    # Dispatch to appropriate odeint subroutine
+    if sensitivity is None:
+        return odeint_inplace(qsolver, y0, tsave)
+    elif sensitivity == 'autograd':
+        return odeint_main(qsolver, y0, tsave)
+    elif sensitivity == 'adjoint':
+        return odeint_adjoint(qsolver, y0, tsave, model_params)
+
+
+# --------------------------------------------------------------------------------------
+#     Core subroutines
+# --------------------------------------------------------------------------------------
+
+
+def odeint_main(qsolver, y0, tsave):
+    if qsolver.options.stepclass == 'fixed':
+        return _fixed_odeint(qsolver, y0, tsave)
+    elif qsolver.options.stepclass == 'adaptive':
+        return _adaptive_odeint(qsolver, y0, tsave)
+
+
+def odeint_inplace(qsolver, y0, tsave):
+    raise NotImplementedError
+
+
+def odeint_adjoint(qsolver, y0, tsave, model_params):
+    raise NotImplementedError
+
+
+def _adaptive_odeint(qsolver, y0, tsave):
+    raise NotImplementedError
+
+
+def _fixed_odeint(qsolver, y0, tsave):
+    # Initialize save tensor
+    ysave = torch.zeros((len(tsave), ) + y0.shape).to(y0)
+    save_counter, save_flag = 0, False
+    if tsave[0] == 0:
+        ysave[0] = y0
+        save_counter += 1
+
+    # Get qsolver fixed time step
+    dt = qsolver.options.dt
+
+    # Run the ODE routine
+    t, y = 0, y0
+    while t < tsave[-1]:
+        # Check if final time is reached
+        if t + dt > tsave[-1]:
+            dt = tsave[-1] - t
+
+        # Iterate solution
+        y = qsolver.forward(t, dt, y)
+        t = t + dt
+
+        # Save solution
+        if t >= tsave[save_counter]:
+            ysave[save_counter] = y
+            save_counter += 1
+
+    return tsave, ysave
+
+
+# --------------------------------------------------------------------------------------
+#     Utility functions
+# --------------------------------------------------------------------------------------
+
+
+def init_tsave(tsave):
+    """Check tsave is a sorted 1-D torch.tensor"""
+    if isinstance(tsave, (list, np.ndarray)):
+        tsave = torch.cat(tsave)
+    if tsave.dim != 1 or len(tsave) == 0:
+        raise ValueError('Argument `tsave` should be a non-empty 1-D torch.Tensor.')
+    if not torch.all(torch.diff(tsave) > 0):
+        raise ValueError(
+            'Argument `tsave` is not sorted in ascending order '
+            'or contains duplicate values.'
+        )
+    return tsave

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -2,29 +2,20 @@ import warnings
 
 import torch
 
-# --------------------------------------------------------------------------------------
-#     Main odeint function
-# --------------------------------------------------------------------------------------
-
 
 def odeint(qsolver, y0, tsave, sensitivity='autograd', model_params=None):
-    # Check arguments
+    # check arguments
     tsave = check_tsave(tsave)
     if (model_params is not None) and (sensitivity in [None, 'autograd']):
         warnings.warn('Argument `model_params` was supplied in `odeint` but not used.')
 
-    # Dispatch to appropriate odeint subroutine
+    # dispatch to appropriate odeint subroutine
     if sensitivity is None:
         return odeint_inplace(qsolver, y0, tsave)
     elif sensitivity == 'autograd':
         return odeint_main(qsolver, y0, tsave)
     elif sensitivity == 'adjoint':
         return odeint_adjoint(qsolver, y0, tsave, model_params)
-
-
-# --------------------------------------------------------------------------------------
-#     Core subroutines
-# --------------------------------------------------------------------------------------
 
 
 def odeint_main(qsolver, y0, tsave):
@@ -47,28 +38,28 @@ def _adaptive_odeint(qsolver, y0, tsave):
 
 
 def _fixed_odeint(qsolver, y0, tsave):
-    # Initialize save tensor
+    # initialize save tensor
     ysave = torch.zeros((len(tsave), ) + y0.shape).to(y0)
     save_counter = 0
     if tsave[0] == 0:
         ysave[0] = y0
         save_counter += 1
 
-    # Get qsolver fixed time step
+    # get qsolver fixed time step
     dt = qsolver.options.dt
 
-    # Run the ODE routine
+    # run the ODE routine
     t, y = 0, y0
     while t < tsave[-1]:
-        # Check if final time is reached
+        # check if final time is reached
         if t + dt > tsave[-1]:
             dt = tsave[-1] - t
 
-        # Iterate solution
+        # iterate solution
         y = qsolver.forward(t, dt, y)
         t = t + dt
 
-        # Save solution
+        # save solution
         if t >= tsave[save_counter]:
             ysave[save_counter] = y
             save_counter += 1
@@ -76,13 +67,8 @@ def _fixed_odeint(qsolver, y0, tsave):
     return tsave, ysave
 
 
-# --------------------------------------------------------------------------------------
-#     Utility functions
-# --------------------------------------------------------------------------------------
-
-
 def check_tsave(tsave):
-    """Check tsave is a sorted 1-D torch.tensor"""
+    """Check tsave is a sorted 1-D `torch.tensor`."""
     if isinstance(tsave, (list, np.ndarray)):
         tsave = torch.cat(tsave)
     if tsave.dim != 1 or len(tsave) == 0:

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -5,12 +5,12 @@ import torch
 from .solver import AdaptativeStep, FixedStep
 
 
-def odeint(qsolver, y0, tsave, sensitivity='autograd', variables=None):
+def odeint(qsolver, y0, tsave, sensitivity='autograd', parameters=None):
     # check arguments
     tsave = torch.tensor(tsave)
     check_tsave(tsave)
-    if (variables is not None) and (sensitivity in [None, 'autograd']):
-        warnings.warn('Argument `variables` was supplied in `odeint` but not used.')
+    if (parameters is not None) and (sensitivity in [None, 'autograd']):
+        warnings.warn('Argument `parameters` was supplied in `odeint` but not used.')
 
     # dispatch to appropriate odeint subroutine
     if sensitivity is None:
@@ -18,7 +18,7 @@ def odeint(qsolver, y0, tsave, sensitivity='autograd', variables=None):
     elif sensitivity == 'autograd':
         return odeint_main(qsolver, y0, tsave)
     elif sensitivity == 'adjoint':
-        return odeint_adjoint(qsolver, y0, tsave, variables)
+        return odeint_adjoint(qsolver, y0, tsave, parameters)
 
 
 def odeint_main(qsolver, y0, tsave):
@@ -35,7 +35,7 @@ def odeint_inplace(qsolver, y0, tsave):
         return odeint_main(qsolver, y0, tsave)
 
 
-def odeint_adjoint(qsolver, y0, tsave, variables):
+def odeint_adjoint(qsolver, y0, tsave, parameters):
     raise NotImplementedError
 
 

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -5,11 +5,11 @@ import torch
 from .solver import AdaptativeStep, FixedStep
 
 
-def odeint(qsolver, y0, tsave, sensitivity='autograd', model_params=None):
+def odeint(qsolver, y0, tsave, sensitivity='autograd', variables=None):
     # check arguments
     tsave = check_tsave(tsave)
-    if (model_params is not None) and (sensitivity in [None, 'autograd']):
-        warnings.warn('Argument `model_params` was supplied in `odeint` but not used.')
+    if (variables is not None) and (sensitivity in [None, 'autograd']):
+        warnings.warn('Argument `variables` was supplied in `odeint` but not used.')
 
     # dispatch to appropriate odeint subroutine
     if sensitivity is None:
@@ -17,7 +17,7 @@ def odeint(qsolver, y0, tsave, sensitivity='autograd', model_params=None):
     elif sensitivity == 'autograd':
         return odeint_main(qsolver, y0, tsave)
     elif sensitivity == 'adjoint':
-        return odeint_adjoint(qsolver, y0, tsave, model_params)
+        return odeint_adjoint(qsolver, y0, tsave, variables)
 
 
 def odeint_main(qsolver, y0, tsave):
@@ -34,7 +34,7 @@ def odeint_inplace(qsolver, y0, tsave):
         return odeint_main(qsolver, y0, tsave)
 
 
-def odeint_adjoint(qsolver, y0, tsave, model_params):
+def odeint_adjoint(qsolver, y0, tsave, variables):
     raise NotImplementedError
 
 

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -7,7 +7,8 @@ from .solver import AdaptativeStep, FixedStep
 
 def odeint(qsolver, y0, tsave, sensitivity='autograd', variables=None):
     # check arguments
-    tsave = check_tsave(tsave)
+    tsave = torch.tensor(tsave)
+    check_tsave(tsave)
     if (variables is not None) and (sensitivity in [None, 'autograd']):
         warnings.warn('Argument `variables` was supplied in `odeint` but not used.')
 
@@ -77,4 +78,3 @@ def check_tsave(tsave):
         raise ValueError('Argument `tsave` must be sorted in strictly ascending order.')
     if not torch.all(tsave >= 0):
         raise ValueError('Argument `tsave` must contain positive values only.')
-    return tsave

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -9,7 +9,7 @@ import torch
 
 def odeint(qsolver, y0, tsave, sensitivity='autograd', model_params=None):
     # Check arguments
-    init_tsave(tsave)
+    tsave = check_tsave(tsave)
     if (model_params is not None) and (sensitivity in [None, 'autograd']):
         warnings.warn('Argument `model_params` was supplied in `odeint` but not used.')
 
@@ -81,7 +81,7 @@ def _fixed_odeint(qsolver, y0, tsave):
 # --------------------------------------------------------------------------------------
 
 
-def init_tsave(tsave):
+def check_tsave(tsave):
     """Check tsave is a sorted 1-D torch.tensor"""
     if isinstance(tsave, (list, np.ndarray)):
         tsave = torch.cat(tsave)

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -28,7 +28,10 @@ def odeint_main(qsolver, y0, tsave):
 
 
 def odeint_inplace(qsolver, y0, tsave):
-    raise NotImplementedError
+    # TODO: Simple solution for now so torch does not store gradients. This
+    #       is probably slower than a genuine in-place solver.
+    with torch.no_grad():
+        return odeint_main(qsolver, y0, tsave)
 
 
 def odeint_adjoint(qsolver, y0, tsave, model_params):

--- a/torchqdynamics/solver.py
+++ b/torchqdynamics/solver.py
@@ -8,11 +8,11 @@ class SolverOption:
 
 @dataclass
 class FixedStep(SolverOption):
-    step: float
+    dt: float
 
 
 @dataclass
-class VariableStep(SolverOption):
+class AdaptativeStep(SolverOption):
     atol: float = 1e-6
     rtol: float = 1e-6
     max_steps: int = 100_000
@@ -20,7 +20,7 @@ class VariableStep(SolverOption):
 
 @dataclass
 class Rouchon(FixedStep):
-    pass
+    order: float = 1.0
 
 
 @dataclass
@@ -29,5 +29,5 @@ class RK4(FixedStep):
 
 
 @dataclass
-class DOPRI6(VariableStep):
+class DOPRI6(AdaptativeStep):
     pass


### PR DESCRIPTION
In this PR, I make an attempt at the overall framework for mesolve (and sesolve, smesolve) and odeint, following the discussion we had the other day.

I introduce a class named `QSolver` which implements a single ODE iteration of any given solver. For now, it is written for first and second-order Rouchon methods.  It can later also be derived into subclasses for other solvers, both fixed and adaptive time steps. It can also easily be derived with the 1.5 order Rouchon scheme of https://github.com/PierreGuilmin/torchqdynamics/pull/5. All Qsolvers will eventually support the `forward_adjoint` method for adjoint-based autodiff. 

Inside `mesolve`, an instance of `QSolver` is created using the solver options dataclass of https://github.com/PierreGuilmin/torchqdynamics/pull/10, and the ODE integrator `odeint` is called. In the end, `odeint` is meant to be common to all main functions of the library, such as `sesolve` and `smesolve`.

I intentionnally made the Hamiltonian `H` time-dependent for now, and the `jump_ops` time-independent, as I believe this should be the most common scenario. Also, `H` is a callable for now, but meant to also accept a `torch.Tensor` or a `List[torch.Tensor]` with time-dependent coefficients in the end. This should be done in a separate PR.

Anyway, I'll let you read this. I tried to be as basic as possible so we can all agree on the framework and then build on it. I found this was a good way to meet all of our demands. I will personnally be able to build on this for the adjoint-based odeint.