### PR TITLE
Improve readability of mesolve/odeint

### DIFF
--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -19,7 +19,7 @@ def mesolve(
     *,
     exp_ops: list[torch.Tensor] = None,
     save_states: bool = True,
-    autodiff: str = None,
+    autodiff_alg: str = None,
     parameters: tuple[nn.Parameter, ...] = None,
     solver: SolverOption = None,
 ):
@@ -43,7 +43,7 @@ def mesolve(
         raise NotImplementedError
 
     # compute the result
-    return odeint(qsolver, rho0, t_save, exp_ops, save_states, autodiff)
+    return odeint(qsolver, rho0, t_save, exp_ops, save_states, autodiff_alg)
 
 
 class MERouchon(AdjointQSolver):

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -1,5 +1,5 @@
 from math import sqrt
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -1,26 +1,27 @@
 from math import sqrt
-from typing import List, Optional
+from typing import Callable
 
 import numpy as np
 import torch
+import torch.nn as nn
 
 from .odeint import AdjointQSolver, odeint
-from .solver import Rouchon
+from .solver import Rouchon, SolverOption
 from .solver_utils import inv_sqrtm, kraus_map
 from .utils import trace
 
 
 def mesolve(
-    H,
-    jump_ops,
-    rho0,
-    t_save,
+    H: torch.Tensor | Callable[[float], torch.Tensor],
+    jump_ops: list[torch.Tensor],
+    rho0: torch.Tensor,
+    t_save: torch.Tensor,
     *,
-    exp_ops: Optional[List[torch.Tensor]] = None,
+    exp_ops: list[torch.Tensor] = None,
     save_states: bool = True,
-    solver=None,
-    sensitivity=None,
-    parameters=None,
+    autodiff: str = None,
+    parameters: tuple[nn.Parameter, ...] = None,
+    solver: SolverOption = None,
 ):
     if isinstance(t_save, (list, np.ndarray)):
         t_save = torch.tensor(t_save)
@@ -42,7 +43,7 @@ def mesolve(
         raise NotImplementedError
 
     # compute the result
-    return odeint(qsolver, rho0, t_save, exp_ops, save_states)
+    return odeint(qsolver, rho0, t_save, exp_ops, save_states, autodiff)
 
 
 class MERouchon(AdjointQSolver):

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -1,5 +1,5 @@
 from math import sqrt
-from typing import Callable
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -12,16 +12,16 @@ from .utils import trace
 
 
 def mesolve(
-    H: torch.Tensor | Callable[[float], torch.Tensor],
-    jump_ops: list[torch.Tensor],
+    H: Union[torch.Tensor, Callable[[float], torch.Tensor]],
+    jump_ops: List[torch.Tensor],
     rho0: torch.Tensor,
     t_save: torch.Tensor,
     *,
-    exp_ops: list[torch.Tensor] = None,
+    exp_ops: Optional[List[torch.Tensor]] = None,
     save_states: bool = True,
-    autodiff_alg: str = None,
-    parameters: tuple[nn.Parameter, ...] = None,
-    solver: SolverOption = None,
+    gradient_alg: Optional[str] = None,
+    parameters: Optional[Tuple[nn.Parameter, ...]] = None,
+    solver: Optional[SolverOption] = None,
 ):
     if isinstance(t_save, (list, np.ndarray)):
         t_save = torch.tensor(t_save)
@@ -43,7 +43,7 @@ def mesolve(
         raise NotImplementedError
 
     # compute the result
-    return odeint(qsolver, rho0, t_save, exp_ops, save_states, autodiff_alg)
+    return odeint(qsolver, rho0, t_save, exp_ops, save_states, gradient_alg)
 
 
 class MERouchon(AdjointQSolver):

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -11,8 +11,16 @@ from .utils import trace
 
 
 def mesolve(
-    H, jump_ops, rho0, t_save, exp_ops: Optional[List[torch.Tensor]] = None,
-    solver=None, sensitivity=None, parameters=None
+    H,
+    jump_ops,
+    rho0,
+    t_save,
+    *,
+    exp_ops: Optional[List[torch.Tensor]] = None,
+    save_states: bool = True,
+    solver=None,
+    sensitivity=None,
+    parameters=None,
 ):
     if isinstance(t_save, (list, np.ndarray)):
         t_save = torch.tensor(t_save)
@@ -34,7 +42,7 @@ def mesolve(
         raise NotImplementedError
 
     # compute the result
-    return odeint(qsolver, rho0, t_save, exp_ops)
+    return odeint(qsolver, rho0, t_save, exp_ops, save_states)
 
 
 class MERouchon(AdjointQSolver):

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
+from typing import List, Optional
 
 import torch
 from tqdm import tqdm
@@ -24,24 +25,24 @@ def odeint(
     qsolver: ForwardQSolver,
     y0: torch.Tensor,
     t_save: torch.Tensor,
-    exp_ops: list[torch.Tensor],
+    exp_ops: List[torch.Tensor],
     save_states: bool,
-    autodiff_alg: str | None,
+    gradient_alg: Optional[str],
 ):
     # check arguments
     check_t_save(t_save)
 
     # dispatch to appropriate odeint subroutine
     args = (qsolver, y0, t_save, exp_ops, save_states)
-    if autodiff_alg is None:
+    if gradient_alg is None:
         return _odeint_inplace(*args)
-    elif autodiff_alg == 'autograd':
+    elif gradient_alg == 'autograd':
         return _odeint_main(*args)
-    elif autodiff_alg == 'adjoint':
+    elif gradient_alg == 'adjoint':
         return _odeint_adjoint(*args)
     else:
         raise ValueError(
-            f'Automatic differentiation algorithm {autodiff_alg} is not defined.'
+            f'Automatic differentiation algorithm {gradient_alg} is not defined.'
         )
 
 

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -26,22 +26,22 @@ def odeint(
     t_save: torch.Tensor,
     exp_ops: list[torch.Tensor],
     save_states: bool,
-    autodiff: str | None,
+    autodiff_alg: str | None,
 ):
     # check arguments
     check_t_save(t_save)
 
     # dispatch to appropriate odeint subroutine
     args = (qsolver, y0, t_save, exp_ops, save_states)
-    if autodiff is None:
+    if autodiff_alg is None:
         return _odeint_inplace(*args)
-    elif autodiff == 'autograd':
+    elif autodiff_alg == 'autograd':
         return _odeint_main(*args)
-    elif autodiff == 'adjoint':
+    elif autodiff_alg == 'adjoint':
         return _odeint_adjoint(*args)
     else:
         raise ValueError(
-            f'Automatic differentiation algorithm {autodiff} is not defined.'
+            f'Automatic differentiation algorithm {autodiff_alg} is not defined.'
         )
 
 

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import List
 
 import torch
 from tqdm import tqdm
@@ -21,34 +20,28 @@ class AdjointQSolver(ForwardQSolver):
         pass
 
 
-class AutoDiffAlgorithm(Enum):
-    AUTOGRAD = 'autograd'  # gradient computed by torch
-    NONE = 'none'  # don't compute the gradients
-    ADJOINT = 'adjoint'  # compute the gradient using the adjoint method
-
-
 def odeint(
-    qsolver,
-    y0,
+    qsolver: ForwardQSolver,
+    y0: torch.Tensor,
     t_save: torch.Tensor,
-    exp_ops: List[torch.Tensor],
+    exp_ops: list[torch.Tensor],
     save_states: bool,
-    autodiff_algorithm=AutoDiffAlgorithm.AUTOGRAD,
+    autodiff: str | None,
 ):
     # check arguments
     check_t_save(t_save)
 
     # dispatch to appropriate odeint subroutine
     args = (qsolver, y0, t_save, exp_ops, save_states)
-    if autodiff_algorithm == AutoDiffAlgorithm.NONE:
+    if autodiff is None:
         return _odeint_inplace(*args)
-    elif autodiff_algorithm == AutoDiffAlgorithm.AUTOGRAD:
+    elif autodiff == 'autograd':
         return _odeint_main(*args)
-    elif autodiff_algorithm == AutoDiffAlgorithm.ADJOINT:
+    elif autodiff == 'adjoint':
         return _odeint_adjoint(*args)
     else:
         raise ValueError(
-            f'Auto differentiation algorithm {autodiff_algorithm} not defined'
+            f'Automatic differentiation algorithm {autodiff} is not defined.'
         )
 
 

--- a/torchqdynamics/utils.py
+++ b/torchqdynamics/utils.py
@@ -115,7 +115,14 @@ def trace(rho):
 
 def expect(operator, state):
     """Compute the expectation value of an operator on a quantum state or density
-    matrix. The method is batchable over the state, but not over the operator."""
+    matrix. The method is batchable over the state, but not over the operator.
+
+    Args:
+        operator: tensor of shape (n, n)
+        state: tensor of shape (..., n, n) or (..., n)
+    Returns:
+        expectation value of shape (...)
+    """
     # TODO: Once QTensor is implemented, check if state is a density matrix or ket.
     # For now, we assume it is a density matrix.
     return torch.einsum('ij,...ji', operator, state)

--- a/torchqdynamics/utils.py
+++ b/torchqdynamics/utils.py
@@ -111,3 +111,11 @@ def lindbladian(
 def trace(rho):
     """Compute the batched trace of a tensor over its last two dimensions."""
     return torch.einsum('...ii', rho)
+
+
+def expect(operator, state):
+    """Compute the expectation value of an operator on a quantum state or density
+    matrix. The method is batchable over the state, but not over the operator."""
+    # TODO: Once QTensor is implemented, check if state is a density matrix or ket.
+    # For now, we assume it is a density matrix.
+    return torch.einsum('ij,...ji', operator, state)


### PR DESCRIPTION
Here is a small PR with a few small modifications on mesolve/odeint before we move on to bigger things. I am building on https://github.com/PierreGuilmin/torchqdynamics/pull/19 and also a bit on https://github.com/PierreGuilmin/torchqdynamics/pull/16. The rationale behind the changes is:

- Added `expect` function to allow batching over `y0`.
- Modified the `times` definition in `fixed_odeint` for robustness. If `dt = 0.099999` and `t_save[-1] =1`, one too many time step was defined by the previous solution.
- Added `save_state` argument all the way up in `mesolve` definition.
- Added a star * in `mesolve` definition to force keyword arguments.
- Added typing in `mesolve` and `odeint` with the latest Python 3.10 format (e.g. `list` instead of `typing.List`, and `x | y` instead of `Union[x,y]`). 
- Finally, on a more controversial topic (sorry I'm annoying @abocquet), I removed the `AutoDiffAlgorithm` enumeration, because I think it was cluttering the readability for not much gained. Plus the user has to import and define an `AutoDiffAlgorithm` upon launching `mesolve` which I think is not a good thing. Unless I'm missing something you intended, I would argue to remove it.