### PR TITLE
Add basic typing

### DIFF
--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -72,7 +72,7 @@ class MERouchon1(MERouchon):
         rho = kraus_map(rho, Ms)
         return rho / trace(rho)[..., None, None].real
 
-    def forward_adjoint(self, t: float, dt: float, phi):
+    def forward_adjoint(self, t: float, dt: float, phi: torch.Tensor):
         raise NotImplementedError
 
 
@@ -95,7 +95,7 @@ class MERouchon1_5(MERouchon):
         rho = kraus_map(rho, Ms)
         return rho
 
-    def forward_adjoint(self, t: float, dt: float, phi):
+    def forward_adjoint(self, t: float, dt: float, phi: torch.Tensor):
         raise NotImplementedError
 
 
@@ -119,5 +119,5 @@ class MERouchon2(MERouchon):
         rho = kraus_map(rho, M0[None, ...]) + rho_ + 0.5 * kraus_map(rho_, M1s)
         return rho / trace(rho)[..., None, None].real
 
-    def forward_adjoint(self, t: float, dt: float, phi):
+    def forward_adjoint(self, t: float, dt: float, phi: torch.Tensor):
         raise NotImplementedError

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -1,30 +1,29 @@
 from math import sqrt
-from typing import Callable, List, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple
 
-import numpy as np
 import torch
 import torch.nn as nn
 
 from .odeint import AdjointQSolver, odeint
 from .solver import Rouchon, SolverOption
 from .solver_utils import inv_sqrtm, kraus_map
+from .types import TensorLike, TimeDependentOperator
 from .utils import trace
 
 
 def mesolve(
-    H: Union[torch.Tensor, Callable[[float], torch.Tensor]],
+    H: TimeDependentOperator,
     jump_ops: List[torch.Tensor],
     rho0: torch.Tensor,
-    t_save: torch.Tensor,
+    t_save: TensorLike,
     *,
     exp_ops: Optional[List[torch.Tensor]] = None,
     save_states: bool = True,
-    gradient_alg: Optional[str] = None,
+    gradient_alg: Literal[None, 'autograd', 'adjoint'] = None,
     parameters: Optional[Tuple[nn.Parameter, ...]] = None,
     solver: Optional[SolverOption] = None,
 ):
-    if isinstance(t_save, (list, np.ndarray)):
-        t_save = torch.tensor(t_save)
+    t_save = torch.as_tensor(t_save)
     if exp_ops is None:
         exp_ops = []
     if solver is None:
@@ -47,7 +46,10 @@ def mesolve(
 
 
 class MERouchon(AdjointQSolver):
-    def __init__(self, H, jump_ops, solver_options):
+    def __init__(
+        self, H: TimeDependentOperator, jump_ops: List[torch.Tensor],
+        solver_options: SolverOption
+    ):
         self.H = H
         self.jump_ops = jump_ops
         self.jumpdag_ops = jump_ops.adjoint()
@@ -57,7 +59,7 @@ class MERouchon(AdjointQSolver):
 
 
 class MERouchon1(MERouchon):
-    def forward(self, t, dt, rho):
+    def forward(self, t: float, dt: float, rho: torch.Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1."""
         # non-hermitian Hamiltonian at time t
         H_nh = self.H(t) - 0.5j * self.sum_nojump
@@ -70,12 +72,12 @@ class MERouchon1(MERouchon):
         rho = kraus_map(rho, Ms)
         return rho / trace(rho)[..., None, None].real
 
-    def forward_adjoint(self, t, dt, phi):
+    def forward_adjoint(self, t: float, dt: float, phi):
         raise NotImplementedError
 
 
 class MERouchon1_5(MERouchon):
-    def forward(self, t, dt, rho):
+    def forward(self, t: float, dt: float, rho: torch.Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1.5."""
         # non-hermitian Hamiltonian at time t
         H_nh = self.H(t) - 0.5j * self.sum_nojump
@@ -93,12 +95,12 @@ class MERouchon1_5(MERouchon):
         rho = kraus_map(rho, Ms)
         return rho
 
-    def forward_adjoint(self, t, dt, phi):
+    def forward_adjoint(self, t: float, dt: float, phi):
         raise NotImplementedError
 
 
 class MERouchon2(MERouchon):
-    def forward(self, t, dt, rho):
+    def forward(self, t: float, dt: float, rho: torch.Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 2.
 
         NOTE: For fast time-varying Hamiltonians, this method is not order 2 because the
@@ -117,5 +119,5 @@ class MERouchon2(MERouchon):
         rho = kraus_map(rho, M0[None, ...]) + rho_ + 0.5 * kraus_map(rho_, M1s)
         return rho / trace(rho)[..., None, None].real
 
-    def forward_adjoint(self, t, dt, phi):
+    def forward_adjoint(self, t: float, dt: float, phi):
         raise NotImplementedError

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -16,7 +16,7 @@ class ForwardQSolver(ABC):
 
 class AdjointQSolver(ForwardQSolver):
     @abstractmethod
-    def forward_adjoint(self, t: float, dt: float, phi):
+    def forward_adjoint(self, t: float, dt: float, phi: torch.Tensor):
         pass
 
 

--- a/torchqdynamics/qtensor.py
+++ b/torchqdynamics/qtensor.py
@@ -40,7 +40,7 @@ class QTensor(torch.Tensor):
         return qt.Qobj(self.numpy(force=True), dims=self.dims)
 
     @staticmethod
-    def from_qutip(x: qt.Qobj) -> torch.tensor:
+    def from_qutip(x: qt.Qobj) -> torch.Tensor:
         """Convert a QuTiP quantum object to a PyTorch tensor.
 
         Note:

--- a/torchqdynamics/solver_utils.py
+++ b/torchqdynamics/solver_utils.py
@@ -1,7 +1,7 @@
 import torch
 
 
-def kraus_map(rho, operators):
+def kraus_map(rho: torch.Tensor, operators: torch.Tensor) -> torch.Tensor:
     """Compute the application of a Kraus map on an input density matrix.
 
     This is equivalent to `torch.sum(operators @ rho[None,...] @ operators.adjoint(),
@@ -17,7 +17,7 @@ def kraus_map(rho, operators):
     return torch.einsum('mij,...jk,mkl->...il', operators, rho, operators.adjoint())
 
 
-def inv_sqrtm(mat):
+def inv_sqrtm(mat: torch.Tensor) -> torch.Tensor:
     """Compute the inverse square root of a matrix using its eigendecomposition.
 
     TODO: Replace with Schur decomposition once released by PyTorch.

--- a/torchqdynamics/types.py
+++ b/torchqdynamics/types.py
@@ -1,0 +1,10 @@
+from typing import Callable, List, Union
+
+import numpy as np
+import torch
+
+# TODO: add typing for Hamiltonian with piecewise-constant factor
+TimeDependentOperator = Union[torch.Tensor, Callable[[float], torch.Tensor]]
+
+# type for objects convertible to a torch tensor using `torch.as_tensor`
+TensorLike = Union[List, np.ndarray, torch.Tensor]

--- a/torchqdynamics/utils.py
+++ b/torchqdynamics/utils.py
@@ -61,7 +61,7 @@ def ket_fidelity(x: torch.Tensor, y: torch.Tensor) -> float:
     return ket_overlap(x, y).abs().pow(2)
 
 
-def dissipator(L: torch.tensor, rho: torch.tensor) -> torch.tensor:
+def dissipator(L: torch.Tensor, rho: torch.Tensor) -> torch.Tensor:
     """Apply the dissipation superoperator to a density matrix.
 
     The dissipation superoperator $\mathcal{D}[L](\cdot)$ is defined by
@@ -108,12 +108,12 @@ def lindbladian(
     return -1j * (H @ rho - rho @ H) + dissipator(Ls, rho).sum(0)
 
 
-def trace(rho):
+def trace(rho: torch.Tensor) -> torch.Tensor:
     """Compute the batched trace of a tensor over its last two dimensions."""
     return torch.einsum('...ii', rho)
 
 
-def expect(operator, state):
+def expect(operator: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
     """Compute the expectation value of an operator on a quantum state or density
     matrix. The method is batchable over the state, but not over the operator.
 


### PR DESCRIPTION
Very basic fixes and type aliases.

A few comments:
- Precisely defining the acceptable `List` type for `TensorLike` requires recursive types and all (for nested lists), I don't think we should go into such trouble.
- We will need to replace `torch.Tensor` by `QTensor` in many places when the class will be ready, I prefer to keep the original torch tensor for now.
- @gautierronan what's the typing for `phi` in `forward_adjoint`?
- Concerning the type aliases, we're not really used to them in typical libraries, but IMO it really makes the big functions signatures like `mesolve` much more readable, and we can use them in all solvers instead of copy pasting lengthy union types like `Union[torch.Tensor, Callable[[float], torch.Tensor]]`. I think for users unaccustomed to Python typing, seeing `TimeDependentOperator` is less scary even if the exact typing is hidden, and we just have to make sure that the doc explains clearly what are the types accepted for time-dependent Hamiltonian.
- Following @gautierronan's PR `odeint` only accepts `torch.Tensor` and not `TensorLike` types for example, assuming all the conversions are done by the callers (i.e. `ssolve`, `mesolve`, etc...). In a way we consider it as a backend method, and we only work with torch tensors in the back.