### PR TITLE
Fix exp_ops for batched rho0 and improve performance by batching operators

### DIFF
--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -25,7 +25,7 @@ def mesolve(
 ):
     t_save = torch.as_tensor(t_save)
     if exp_ops is None:
-        exp_ops = []
+        exp_ops = torch.tensor([])
     else:
         exp_ops = torch.stack(exp_ops)
     if solver is None:

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -26,6 +26,8 @@ def mesolve(
     t_save = torch.as_tensor(t_save)
     if exp_ops is None:
         exp_ops = []
+    else:
+        exp_ops = torch.stack(exp_ops)
     if solver is None:
         # TODO: Replace by adaptive time step solver when implemented.
         solver = Rouchon(dt=1e-2)

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -92,7 +92,7 @@ def _fixed_odeint(
         y_save = torch.zeros(len(t_save), *y0.shape).to(y0)
 
     if len(exp_ops) > 0:
-        exp_save = torch.zeros(len(exp_ops), len(t_save)).to(y0)
+        exp_save = torch.zeros(*y0.shape[:-2], len(exp_ops), len(t_save)).to(y0)
 
     # define time values
     # Note that defining the solver times as `torch.arange(0.0, t_save[-1], dt)`
@@ -114,7 +114,7 @@ def _fixed_odeint(
             if save_states:
                 y_save[save_counter] = y
             for j, op in enumerate(exp_ops):
-                exp_save[j, save_counter] = expect(op, y)
+                exp_save[:, j, save_counter] = expect(op, y)
             save_counter += 1
 
         # iterate solution
@@ -124,7 +124,7 @@ def _fixed_odeint(
     if save_states:
         y_save[save_counter] = y
     for j, op in enumerate(exp_ops):
-        exp_save[j, save_counter] = expect(op, y)
+        exp_save[:, j, save_counter] = expect(op, y)
 
     return y_save, exp_save
 

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import List, Literal
+from typing import Literal
 
 import torch
 from tqdm import tqdm
 
 from .solver import AdaptativeStep, FixedStep
-from .utils import expect
+from .solver_utils import bexpect
 
 
 class ForwardQSolver(ABC):
@@ -24,7 +24,7 @@ def odeint(
     qsolver: ForwardQSolver,
     y0: torch.Tensor,
     t_save: torch.Tensor,
-    exp_ops: List[torch.Tensor],
+    exp_ops: torch.Tensor,
     save_states: bool,
     gradient_alg: Literal[None, 'autograd', 'adjoint'],
 ):
@@ -47,7 +47,7 @@ def odeint(
 
 def _odeint_main(
     qsolver: ForwardQSolver, y0: torch.Tensor, t_save: torch.Tensor,
-    exp_ops: List[torch.Tensor], save_states: bool
+    exp_ops: torch.Tensor, save_states: bool
 ):
     if isinstance(qsolver.options, FixedStep):
         return _fixed_odeint(
@@ -77,7 +77,7 @@ def _adaptive_odeint(*_args, **_kwargs):
 
 def _fixed_odeint(
     qsolver: ForwardQSolver, y0: torch.Tensor, t_save: torch.Tensor, dt: float,
-    exp_ops: List[torch.Tensor], save_states: bool
+    exp_ops: torch.Tensor, save_states: bool
 ):
     # assert that `t_save` values are multiples of `dt` (with the default
     # `rtol=1e-5` they differ by at most 0.001% from a multiple of `dt`)
@@ -113,8 +113,8 @@ def _fixed_odeint(
         if t >= t_save[save_counter]:
             if save_states:
                 y_save[save_counter] = y
-            for j, op in enumerate(exp_ops):
-                exp_save[:, j, save_counter] = expect(op, y)
+            if len(exp_ops) > 0:
+                exp_save[..., save_counter] = bexpect(exp_ops, y)
             save_counter += 1
 
         # iterate solution
@@ -123,8 +123,8 @@ def _fixed_odeint(
     # save final time step (`t` goes `0.0` to `t_save[-1]` excluded)
     if save_states:
         y_save[save_counter] = y
-    for j, op in enumerate(exp_ops):
-        exp_save[:, j, save_counter] = expect(op, y)
+    if len(exp_ops) > 0:
+        exp_save[..., save_counter] = bexpect(exp_ops, y)
 
     return y_save, exp_save
 

--- a/torchqdynamics/solver_utils.py
+++ b/torchqdynamics/solver_utils.py
@@ -35,11 +35,11 @@ def bexpect(operators: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
     density matrix. The method is batchable over the operators and the state.
 
     Args:
-        operators: tensor of shape (m, n, n)
+        operators: tensor of shape (b, n, n)
         state: tensor of shape (..., n, n) or (..., n)
     Returns:
         expectation value of shape (..., m)
     """
     # TODO: Once QTensor is implemented, check if state is a density matrix or ket.
     # For now, we assume it is a density matrix.
-    return torch.einsum('mij,...ji->...m', operators, state)
+    return torch.einsum('bij,...ji->...b', operators, state)

--- a/torchqdynamics/solver_utils.py
+++ b/torchqdynamics/solver_utils.py
@@ -28,3 +28,18 @@ def inv_sqrtm(mat: torch.Tensor) -> torch.Tensor:
     """
     vals, vecs = torch.linalg.eigh(mat)
     return vecs @ torch.linalg.solve(vecs, torch.diag(vals**(-0.5)), left=False)
+
+
+def bexpect(operators: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
+    """Compute the expectation values of many operators on a quantum state or
+    density matrix. The method is batchable over the operators and the state.
+
+    Args:
+        operators: tensor of shape (m, n, n)
+        state: tensor of shape (..., n, n) or (..., n)
+    Returns:
+        expectation value of shape (..., m)
+    """
+    # TODO: Once QTensor is implemented, check if state is a density matrix or ket.
+    # For now, we assume it is a density matrix.
+    return torch.einsum('mij,...ji->...m', operators, state)


### PR DESCRIPTION
This PR does two thing:

- Fix `exp_ops` for batched `rho0` (current implementation was bugged)
- Improve the performance by batching operators for the computation of expectation values
  <details>
  <summary>Test code benchmarking previous performance with new change</summary>

  ```python
  import torch.utils.benchmark as benchmark
  
  N = 100
  ops = torch.rand(8, N, N)
  rho = torch.rand(3, N, N)
  
  eops1 = '[torch.einsum("ij,...ji", op, rho) for op in ops]'
  eops2 = 'torch.einsum("mij,...ji->...m", ops, rho)'
  
  t1 = benchmark.Timer(stmt=eops1, globals={'ops': ops, 'rho': rho})
  t2 = benchmark.Timer(stmt=eops2, globals={'ops': ops, 'rho': rho})
  
  print(t1.timeit(1000))
  print(t2.timeit(1000))
  ```
  with output
  ```text
  [torch.einsum("ij,...ji", op, rho) for op in ops]
    332.01 us
    1 measurement, 1000 runs , 1 thread
  torch.einsum("mij,...ji->...m", ops, rho)
    110.80 us
    1 measurement, 1000 runs , 1 thread
  ```
  </details>

Here's some minimal code to test the batching (note that it also works when `rho0` is not batched and has shape `(d, d)`). This computes the expectation values of $X$ and $P$ of a spiraling cavity starting in four different initial states (batched in `rho0`)
<details>
  <summary>Minimal code example</summary>

```python
import numpy as np
import qutip as qt
import torchqdynamics as tq
import torch

def from_qutip(x):
    return torch.from_numpy(x.full())

d = 64
kappa = 1.5
delta = 4 * np.pi
alpha0 = 2.0 + 2.0j

a = qt.destroy(d)
adag = a.dag()

H = lambda t: from_qutip(delta * adag * a)
jump_ops = torch.stack([from_qutip(np.sqrt(kappa) * a)])
# 4 initial states
rho0 = torch.stack(
    [
        from_qutip(qt.ket2dm(qt.coherent(d, alpha0))),
        from_qutip(qt.ket2dm(qt.coherent(d, 1j * alpha0))),
        from_qutip(qt.ket2dm(qt.coherent(d, -alpha0))),
        from_qutip(qt.ket2dm(qt.coherent(d, -1j * alpha0))),
    ]
)
tsave = np.linspace(0.0, 1.0, 21)
# 2 expectation value operators
exp_ops = [from_qutip((a+adag)/2), from_qutip((a-adag)/(2j))]
solver = tq.solver.Rouchon(dt=1e-4, order=1)

states, exp = tq.mesolve(H, jump_ops, rho0, tsave, exp_ops=exp_ops, solver=solver)
print(states.shape)
print(exp.shape)
```
with output
```
torch.Size([21, 4, 64, 64])
torch.Size([4, 2, 21])
```
</details>