### PR TITLE
Accept qutip `QObj` in `mesolve` and ket for `rho0`

### DIFF
--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -8,7 +8,7 @@ from .odeint import AdjointQSolver, odeint
 from .solver import Rouchon, SolverOption
 from .solver_utils import inv_sqrtm, kraus_map
 from .types import TensorLike, TimeDependentOperator
-from .utils import trace
+from .utils import is_ket, ket_to_dm, trace
 
 
 def mesolve(
@@ -42,6 +42,8 @@ def mesolve(
     jump_ops = torch.stack(jump_ops)
 
     # batch rho0 by default
+    if is_ket(rho0):
+        rho0 = ket_to_dm(rho0)
     rho0_batched = rho0[None, ...] if rho0.dim() == 2 else rho0
 
     t_save = torch.as_tensor(t_save)

--- a/torchqdynamics/types.py
+++ b/torchqdynamics/types.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Union, get_args
+from typing import Callable, List, Optional, Union, get_args
 
 import numpy as np
 import torch
@@ -12,25 +12,37 @@ TimeDependentOperator = Union[torch.Tensor, Callable[[float], torch.Tensor]]
 # type for objects convertible to a torch tensor using `torch.as_tensor`
 TensorLike = Union[List, np.ndarray, torch.Tensor]
 
-# type for objects convertible to a torch tensor using `torchqdynamics.to_tensor`
-QTensorLike = Union[TensorLike, Qobj]
+# type for objects convertible to a torch tensor using `to_tensor`
+OperatorLike = Union[TensorLike, Qobj]
+
+# type for objects convertible to a `TimeDependentOperator` using `time_dependent_to_tensor`
+TimeDependentOperatorLike = Union[OperatorLike, Callable[[float], OperatorLike]]
 
 
-def to_torch(x: QTensorLike) -> torch.Tensor:
-    """Convert a `QTensorLike` object to a PyTorch tensor.
+def to_tensor(x: Optional[Union[OperatorLike, List[OperatorLike]]]) -> torch.Tensor:
+    """Convert a `OperatorLike` object or a list of `OperatorLike` object to a PyTorch
+    tensor.
 
     Args:
-        x: QuTiP quantum object or NumPy array or Python list or PyTorch tensor.
+        x: QuTiP quantum object or NumPy array or Python list or PyTorch tensor or list
+           of these types. If `None` or empty list, returns an empty tensor of size (0).
 
     Returns:
         PyTorch tensor.
     """
+    if x is None:
+        return torch.tensor([])
+    if isinstance(x, list):
+        if len(x) == 0:
+            return torch.tensor([])
+        return torch.stack([to_tensor(y) for y in x])
     if isinstance(x, Qobj):
         return from_qutip(x)
     elif isinstance(x, get_args(TensorLike)):
         return torch.as_tensor(x)
     else:
         raise TypeError(
-            f'Input of type {type(x)} is not supported. `to_torch` only supports QuTiP '
-            'quantum object, NumPy array, Python list or PyTorch tensor.'
+            f'Input of type {type(x)} is not supported. `to_tensor` only '
+            'supports QuTiP quantum object, NumPy array, Python list or PyTorch tensor '
+            'or list of these types.'
         )

--- a/torchqdynamics/utils.py
+++ b/torchqdynamics/utils.py
@@ -4,6 +4,10 @@ import torch
 from qutip import Qobj
 
 
+def is_ket(x: torch.Tensor) -> torch.Tensor:
+    return x.size(-1) == 1
+
+
 def ket_to_bra(x: torch.Tensor) -> torch.Tensor:
     """Linear map (bra) representation of a state vector (ket).
 


### PR DESCRIPTION
This is a game changer for adoption, our mesolve can now be a drop-in replacement for qutip mesolve.

<details>
  <summary>Spiraling cavity example</summary>
  
  ```python
# parameters
d = 32
kappa = 1.5
delta = 4 * np.pi
alpha0 = 1.0 + 1.0j

# operators
a = qt.destroy(d)
adag = a.dag()
H = delta * adag * a
jump_ops = [np.sqrt(kappa) * a]
exp_ops = [(a+adag)/np.sqrt(2), (a-adag)/(np.sqrt(2) * 1j)]

# other arguments
rho0 = qt.coherent(d, alpha0)
tsave = np.linspace(0.0, 1.0, 11)
solver = tq.solver.Rouchon(dt=1e-4, order=1)

# solve
states, exp = tq.mesolve(H, jump_ops, rho0, tsave, exp_ops=exp_ops, solver=solver)

# result
print(states.shape)
print(exp.shape)
```
</details>

Note that will also make test writing a breeze, we can focus on physical examples.

I think we maybe also need an optional layer of conversion back from `torch.Tensor` to `qutip.Qobj` for the returned objects, depending on a parameter set by the user?