### PR TITLE
Test `mesolve` batching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,10 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run import sorting (isort)
-        run: isort --check torchqdynamics
+        run: isort --check .
 
       - name: Run code autoformatting (yapf)
-        run: yapf --diff --recursive torchqdynamics
+        run: yapf --diff --recursive torchqdynamics tests
 
       - name: Run test suite (pytest)
         run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-files: torchqdynamics
+files: (torchqdynamics|tests)
 repos:
   - repo: https://github.com/google/yapf
     rev: v0.32.0

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ pip install -r requirements-dev.txt
 
 Run the following before each commit:
 ```shell
-isort torchqdynamics  # sort the imports
-yapf -i -r torchqdynamics  # auto-format the code
+isort .  # sort the imports
+yapf -i -r torchqdynamics tests  # auto-format the code
 pytest  # run the test suite
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,4 @@ split_before_named_assigns = false
 profile = "black"
 line_length = 88  # to be consistent with yapf
 skip = ["__init__.py"]
+src_paths = ["torchqdynamics", "tests"]

--- a/tests/test_foo.py
+++ b/tests/test_foo.py
@@ -1,2 +1,0 @@
-def test_foo():
-    assert 42 == 42

--- a/tests/test_mesolve.py
+++ b/tests/test_mesolve.py
@@ -16,7 +16,7 @@ def test_mesolve_batching():
     a = qt.destroy(n)
     adag = a.dag()
     H = delta * adag * a
-    H_batched = [0.5 * delta * adag * a, delta * adag * a, 2 * delta * adag * a]
+    H_batched = [0.5 * H, H, 2 * H]
     b_H = len(H_batched)
     jump_ops = [np.sqrt(kappa) * a, np.sqrt(kappa) * a]
     exp_ops = [(a + adag) / np.sqrt(2), (a - adag) / (np.sqrt(2) * 1j)]
@@ -32,7 +32,7 @@ def test_mesolve_batching():
     ]
     b_rho0 = len(rho0_batched)
     num_t_save = 51
-    t_save = np.linspace(0.0, delta / (2 * np.pi), num_t_save)  # a full tour
+    t_save = np.linspace(0.0, delta / (2 * np.pi), num_t_save)  # a full rotation
     solver = tq.solver.Rouchon(dt=1e-4, order=1)
 
     run_mesolve = lambda H, rho0: tq.mesolve(
@@ -55,7 +55,6 @@ def test_mesolve_batching():
     assert exp.shape == (b_rho0, num_exp_ops, num_t_save)
 
     # batched H and rho0
-    H_batched = [0.5 * H, H, 2 * H]
     states, exp = run_mesolve(H_batched, rho0_batched)
     assert states.shape == (b_H, b_rho0, num_t_save, n, n)
     assert exp.shape == (b_H, b_rho0, num_exp_ops, num_t_save)

--- a/tests/test_mesolve.py
+++ b/tests/test_mesolve.py
@@ -1,0 +1,61 @@
+import numpy as np
+import qutip as qt
+
+import torchqdynamics as tq
+
+
+def test_mesolve_batching():
+    """Test the batching of H and rho0 in mesolve, and the returned object sizes."""
+    # parameters
+    n = 8
+    kappa = 1.0
+    delta = 2 * np.pi
+    alpha0 = 1.0
+
+    # operators
+    a = qt.destroy(n)
+    adag = a.dag()
+    H = delta * adag * a
+    H_batched = [0.5 * delta * adag * a, delta * adag * a, 2 * delta * adag * a]
+    b_H = len(H_batched)
+    jump_ops = [np.sqrt(kappa) * a, np.sqrt(kappa) * a]
+    exp_ops = [(a + adag) / np.sqrt(2), (a - adag) / (np.sqrt(2) * 1j)]
+    num_exp_ops = len(exp_ops)
+
+    # other arguments
+    rho0 = qt.coherent(n, alpha0)
+    rho0_batched = [
+        qt.coherent(n, alpha0),
+        qt.coherent(n, 1j * alpha0),
+        qt.coherent(n, -alpha0),
+        qt.coherent(n, -1j * alpha0)
+    ]
+    b_rho0 = len(rho0_batched)
+    num_t_save = 51
+    t_save = np.linspace(0.0, delta / (2 * np.pi), num_t_save)  # a full tour
+    solver = tq.solver.Rouchon(dt=1e-4, order=1)
+
+    run_mesolve = lambda H, rho0: tq.mesolve(
+        H, jump_ops, rho0, t_save, exp_ops=exp_ops, solver=solver
+    )
+
+    # no batching
+    states, exp = run_mesolve(H, rho0)
+    assert states.shape == (num_t_save, n, n)
+    assert exp.shape == (num_exp_ops, num_t_save)
+
+    # batched H
+    states, exp = run_mesolve(H_batched, rho0)
+    assert states.shape == (b_H, num_t_save, n, n)
+    assert exp.shape == (b_H, num_exp_ops, num_t_save)
+
+    # batched rho0
+    states, exp = run_mesolve(H, rho0_batched)
+    assert states.shape == (b_rho0, num_t_save, n, n)
+    assert exp.shape == (b_rho0, num_exp_ops, num_t_save)
+
+    # batched H and rho0
+    H_batched = [0.5 * H, H, 2 * H]
+    states, exp = run_mesolve(H_batched, rho0_batched)
+    assert states.shape == (b_H, b_rho0, num_t_save, n, n)
+    assert exp.shape == (b_H, b_rho0, num_exp_ops, num_t_save)


### PR DESCRIPTION
Built on top of #31.

This is not **at all** a complete test suite for `mesolve`, it's just to test that the batching works and that the Rouchon 1 method runs with no bug (which does not mean that the result is correct 😋). I also took the chance to have isort and yapf run on the tests directory.