### PR TITLE
Rename types and begin `mesolve` documentation

### DIFF
--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -34,14 +34,18 @@ def mesolve(
     The function can be differentiated over using either the default Pytorch autograd
     library (`gradient_alg="autograd"`), or a custom adjoint state differentiation
     (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward
-    pass, such as a Rouchon solver, should be called. The parameters to compute the
-    gradients with respect to should also be passed with the `parameters` argument. If
-    differentiation is not required (`gradient_alg=None`), the graph of operation is
-    not stored thus increasing the solver performance.
+    pass should be used (e.g. a Rouchon solver). By default, `gradient_alg=None` is
+    called, in which case the graph of operation is not stored for improved solver
+    performance.
 
-    For time-dependent Hamiltonians, `H` can be TODO
+    For time-dependent problems, the Hamiltonian `H` can be passed as a callable with
+    signature float -> Tensor. Piece-wise constant Hamiltonians can also be passed as...
+    TODO: complete with Hamiltonian format
 
-    Available solvers: `Rouchon` (alias of `Rouchon2`), `Rouchon1`, `Rouchon1_5`.
+    Available solvers:
+        `Rouchon` (alias of `Rouchon2`)
+        `Rouchon1`
+        `Rouchon1_5`
 
     Args:
         H : Hamiltonian of shape (n,n) or (b_H, n, n) if batched.

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -28,17 +28,17 @@ def mesolve(
 
     The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to
     solve multiple master equations in a single run. The jump operators `jump_ops` and
-    time list `t_save` should however be common to all batches.
+    time list `t_save` are common to all batches.
 
-    `mesolve` can be differentiated over using either the default Pytorch autograd
+    `mesolve` can be differentiated through using either the default Pytorch autograd
     library (`gradient_alg="autograd"`), or a custom adjoint state differentiation
-    (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the
-    backward pass should be used (e.g. Rouchon solver). By default, the graph of
-    operations is not stored for improved performance of the solver.
+    (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward
+    pass should be used (e.g. Rouchon solver). By default (if no gradient is required),
+    the graph of operations is not stored for improved performance of the solver.
 
     For time-dependent problems, the Hamiltonian `H` can be passed as a function with
-    signature float -> Tensor. Piece-wise constant Hamiltonians can also be passed as...
-    TODO: complete with Hamiltonian format
+    signature `H(t: float) -> Tensor`. Piecewise constant Hamiltonians can also be
+    passed as... TODO: complete with Hamiltonian format
 
     Available solvers:
       - `Rouchon` (alias of `Rouchon2`)

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -68,11 +68,11 @@ def mesolve(
             respect to during the backward pass.
 
     Returns:
-        A tuple `(rho_save, exp_save)` where
-            `rho_save` is a tensor with the computed density matrices at `t_save`
+        A tuple ``(rho_save, exp_save)`` where
+            ``rho_save`` is a tensor with the computed density matrices at ``t_save``
                 times, and of shape (len(t_save), n, n) or
                 (b_H, b_rho, len(t_save), n, n) if batched.
-            `exp_save` is a tensor with the computed expectation values at `t_save`
+            ``exp_save`` is a tensor with the computed expectation values at ``t_save``
                 times, and of shape (len(exp_ops), len(t_save)) or
                 (b_H, b_rho, len(exp_ops), len(t_save)) if batched.
     """

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -202,11 +202,13 @@ class MERouchon1_5(MERouchon):
 
 class MERouchon2(MERouchon):
     def forward(self, t: float, dt: float, rho: Tensor):
-        """Compute rho(t+dt) using a Rouchon method of order 2.
+        r"""Compute rho(t+dt) using a Rouchon method of order 2.
 
-        NOTE: For fast time-varying Hamiltonians, this method is not order 2 because the
-        second-order time derivative term is neglected. This term could be added in the
-        zero-th order Kraus operator if needed, as M0 += -0.5j * dt**2 * \dot{H}.
+        .. note::
+            For fast time-varying Hamiltonians, this method is not order 2 because the
+            second-order time derivative term is neglected. This term could be added in
+            the zero-th order Kraus operator if needed, as
+            ``M0 += -0.5j * dt**2 * \dot{H}``.
         """
         # Args:
         #     rho: (b_H, b_rho, n, n)

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -8,12 +8,12 @@ from torch import Tensor
 from .odeint import AdjointQSolver, odeint
 from .solver import Rouchon, SolverOption
 from .solver_utils import inv_sqrtm, kraus_map
-from .types import TensorLike, TensorTD
+from .types import TDOperator, TensorLike
 from .utils import trace
 
 
 def mesolve(
-    H: TensorTD,
+    H: TDOperator,
     jump_ops: List[Tensor],
     rho0: Tensor,
     t_save: TensorLike,
@@ -24,55 +24,56 @@ def mesolve(
     gradient_alg: Optional[Literal['autograd', 'adjoint']] = None,
     parameters: Optional[Tuple[nn.Parameter, ...]] = None,
 ) -> Tuple[Tensor, Tensor]:
-    r"""Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
+    """Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
 
-    The Hamiltonian ``H`` and the initial density matrix ``rho0`` can be batched over to
-    solve multiple master equations in a single run. The jump operators ``jump_ops`` and
-    time list ``t_save`` should however be common to all batches.
+    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to
+    solve multiple master equations in a single run. The jump operators `jump_ops` and
+    time list `t_save` should however be common to all batches.
 
-    ``mesolve`` can be differentiated over using either the default Pytorch autograd
-    library (``gradient_alg="autograd"``), or a custom adjoint state differentiation
-    (``gradient_alg="adjoint"``). For the latter, a solver that is stable in the
+    `mesolve` can be differentiated over using either the default Pytorch autograd
+    library (`gradient_alg="autograd"`), or a custom adjoint state differentiation
+    (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the
     backward pass should be used (e.g. Rouchon solver). By default, the graph of
     operations is not stored for improved performance of the solver.
 
-    For time-dependent problems, the Hamiltonian ``H`` can be passed as a function with
+    For time-dependent problems, the Hamiltonian `H` can be passed as a function with
     signature float -> Tensor. Piece-wise constant Hamiltonians can also be passed as...
     TODO: complete with Hamiltonian format
 
     Available solvers:
-        `Rouchon` (alias of `Rouchon2`)
-        `Rouchon1`
-        `Rouchon1_5`
+      - `Rouchon` (alias of `Rouchon2`)
+      - `Rouchon1`
+      - `Rouchon1_5`
 
     Args:
         H (Tensor or Callable): Hamiltonian.
-            Can be a tensor of shape (n, n), a tensor of shape (b_H, n, n) if batched,
-            or a callable ``H(t: float) -> Tensor`` that returns a tensor of either
-            possible shapes at every time between ``t=0`` and ``t=t_save[-1]``.
-        jump_ops (List[Tensor]): List of jump operators.
+            Can be a tensor of shape (n, n) or (b_H, n, n) if batched, or a callable
+            `H(t: float) -> Tensor` that returns a tensor of either possible shapes
+            at every time between `t=0` and `t=t_save[-1]`.
+        jump_ops (list of Tensor): List of jump operators.
             Each jump operator should be a tensor of shape (n, n).
         rho0 (Tensor): Initial density matrix.
-            Tensor of shape (n, n), or tensor of shape (b_rho, n, n) if batched.
-        t_save (TensorLike): Array of times for which results are saved.
-            The last value ``t_save[-1]`` defines the total time of evolution.
-        save_states (bool, optional): If ``True``, the density matrix is saved at every
-            time value in ``t_save``. Defaults to ``True``.
-        exp_ops (List[Tensor], optional): List of operators for which the expectation
-            value is computed at every time value in ``t_save``.
+            Tensor of shape (n, n) or (b_rho, n, n) if batched.
+        t_save (Tensor, np.ndarray or list): Times for which results are saved.
+            The master equation is solved from time `t=0.0` to `t=t_save[-1]`.
+        save_states (bool, optional): If `True`, the density matrix is saved at every
+            time value in `t_save`. If `False`, only the final density matrix is
+            stored and returned. Defaults to `True`.
+        exp_ops (list of Tensor, optional): List of operators for which the expectation
+            value is computed at every time value in `t_save`.
         solver (SolverOption, optional): Solver used to compute the master equation
             solutions. See the list of available solvers.
         gradient_alg (str, optional): Algorithm used for computing gradients in the
-            backward pass. Defaults to ``None``.
-        parameters (tuple of nn.Parameter): Parameters that gradients are computed with
-            respect to during the backward pass.
+            backward pass. Defaults to `None`.
+        parameters (tuple of nn.Parameter): Parameters with respect to which gradients
+            are computed during the adjoint state backward pass.
 
     Returns:
-        A tuple ``(rho_save, exp_save)`` where
-            ``rho_save`` is a tensor with the computed density matrices at ``t_save``
+        A tuple `(rho_save, exp_save)` where
+            `rho_save` is a tensor with the computed density matrices at `t_save`
                 times, and of shape (len(t_save), n, n) or
                 (b_H, b_rho, len(t_save), n, n) if batched.
-            ``exp_save`` is a tensor with the computed expectation values at ``t_save``
+            `exp_save` is a tensor with the computed expectation values at `t_save`
                 times, and of shape (len(exp_ops), len(t_save)) or
                 (b_H, b_rho, len(exp_ops), len(t_save)) if batched.
     """
@@ -80,13 +81,13 @@ def mesolve(
     H_batched = H[None, ...] if H.dim() == 2 else H
 
     if len(jump_ops) == 0:
-        raise ValueError('Argument `jump_ops` must be a non-empty list of Tensors.')
+        raise ValueError('Argument `jump_ops` must be a non-empty list of tensors.')
     jump_ops = torch.stack(jump_ops)
 
     # batch rho0 by default
     b_H = H_batched.size(0)
     rho0_batched = rho0[None, ...] if rho0.dim() == 2 else rho0
-    rho0_batched = rho0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_rho?, n, n)
+    rho0_batched = rho0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_rho, n, n)
 
     t_save = torch.as_tensor(t_save)
     if exp_ops is None:
@@ -125,7 +126,7 @@ def mesolve(
 
 
 class MERouchon(AdjointQSolver):
-    def __init__(self, H: TensorTD, jump_ops: Tensor, solver_options: SolverOption):
+    def __init__(self, H: TDOperator, jump_ops: Tensor, solver_options: SolverOption):
         # Args:
         #     H: (b_H, n, n)
 
@@ -204,11 +205,11 @@ class MERouchon2(MERouchon):
     def forward(self, t: float, dt: float, rho: Tensor):
         r"""Compute rho(t+dt) using a Rouchon method of order 2.
 
-        .. note::
+        Note:
             For fast time-varying Hamiltonians, this method is not order 2 because the
             second-order time derivative term is neglected. This term could be added in
-            the zero-th order Kraus operator if needed, as
-            ``M0 += -0.5j * dt**2 * \dot{H}``.
+            the zero-th order Kraus operator if needed, as `M0 += -0.5j * dt**2 *
+            \dot{H}`.
         """
         # Args:
         #     rho: (b_H, b_rho, n, n)

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -30,7 +30,7 @@ def mesolve(
     solve multiple master equations in a single run. The jump operators `jump_ops` and
     time list `t_save` are common to all batches.
 
-    `mesolve` can be differentiated through using either the default Pytorch autograd
+    `mesolve` can be differentiated through using either the default PyTorch autograd
     library (`gradient_alg="autograd"`), or a custom adjoint state differentiation
     (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward
     pass should be used (e.g. Rouchon solver). By default (if no gradient is required),
@@ -71,11 +71,12 @@ def mesolve(
     Returns:
         A tuple `(rho_save, exp_save)` where
             `rho_save` is a tensor with the computed density matrices at `t_save`
-                times, and of shape (len(t_save), n, n) or
-                (b_H, b_rho, len(t_save), n, n) if batched.
+                times, and of shape (len(t_save), n, n) or (b_H, b_rho, len(t_save), n,
+                n) if batched. If `save_states` is `False`, only the final density
+                matrix is returned with the same shape as the initial input.
             `exp_save` is a tensor with the computed expectation values at `t_save`
-                times, and of shape (len(exp_ops), len(t_save)) or
-                (b_H, b_rho, len(exp_ops), len(t_save)) if batched.
+                times, and of shape (len(exp_ops), len(t_save)) or (b_H, b_rho,
+                len(exp_ops), len(t_save)) if batched.
     """
     # batch H by default
     H_batched = H[None, ...] if H.dim() == 2 else H

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -24,6 +24,40 @@ def mesolve(
     gradient_alg: Optional[Literal['autograd', 'adjoint']] = None,
     parameters: Optional[Tuple[nn.Parameter, ...]] = None,
 ):
+    """
+    Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
+
+    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to solve multiple master equations in a single run. The jump operators `jump_ops` and time list `t_save` should however be common to all batches.
+
+    The function can be differentiated over using either the default Pytorch autograd library (`gradient_alg="autograd"`), or a custom adjoint state differentiation (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward pass, such as a Rouchon solver, should be called. The parameters to compute the gradients with respect to should also be passed with the `parameters` argument. If differentiation is not required (`gradient_alg=None`), the graph of operation is not stored thus increasing the solver performance.
+
+    For time-dependent Hamiltonians, `H` can be TODO
+
+    Available solvers: `Rouchon` (alias of `Rouchon2`), `Rouchon1`, `Rouchon1_5`.
+
+    Args:
+        H : Hamiltonian of shape (n,n) or (b_H, n, n) if batched.
+        jump_ops : List of jump operators of shape (n, n).
+        rho0 : Initial density matrix of shape (n, n) or (b_rho, n, n) if batched.
+        t_save : Array of times to save results at. `t_save[-1]` defines the total
+            evolution time of the master equation.
+        save_states : Whether to save the computed density matrices at every time
+            specified by `t_save` or not. Defaults to True.
+        exp_ops : List of operators to compute the expectation value of.
+        solver : Solver used to compute the master equation solutions.
+        gradient_alg : Algorithm used to differentiate through the function.
+        parameters : Parameters that gradients are computed with respect to in the
+            backward pass.
+
+    Returns:
+        A tuple `(y_save, exp_save)` where
+            `y_save` is a tensor with the computed density matrices at `t_save`
+                times, and of shape (len(t_save), n, n) or
+                (b_H, b_rho, len(t_save), n, n) if batched.
+            `exp_save` is a tensor with the computed expectation values at `t_save`
+                times, and of shape (len(exp_ops), len(t_save)) or
+                (b_H, b_rho, len(exp_ops), len(t_save)) if batched.
+    """
     # Args:
     #     H: (b_H?, n, n)
     #     rho0: (b_rho0?, n, n)

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -27,7 +27,9 @@ def mesolve(
     """
     Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
 
-    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to solve multiple master equations in a single run. The jump operators `jump_ops` and time list `t_save` should however be common to all batches.
+    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to
+    solve multiple master equations in a single run. The jump operators `jump_ops` and
+    time list `t_save` should however be common to all batches.
 
     The function can be differentiated over using either the default Pytorch autograd library (`gradient_alg="autograd"`), or a custom adjoint state differentiation (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward pass, such as a Rouchon solver, should be called. The parameters to compute the gradients with respect to should also be passed with the `parameters` argument. If differentiation is not required (`gradient_alg=None`), the graph of operation is not stored thus increasing the solver performance.
 

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -56,12 +56,10 @@ def mesolve(
             Tensor of shape (n, n), or tensor of shape (b_rho, n, n) if batched.
         t_save (TensorLike): Array of times for which results are saved.
             The last value ``t_save[-1]`` defines the total time of evolution.
-        save_states (bool, optional):
-            If ``True``, the density matrix is saved at every time value in ``t_save``.
-            Defaults to ``True``.
-        exp_ops (List[Tensor], optional):
-            List of operators for which the expectation value is computed at every time
-            value in ``t_save``.
+        save_states (bool, optional): If ``True``, the density matrix is saved at every
+            time value in ``t_save``. Defaults to ``True``.
+        exp_ops (List[Tensor], optional): List of operators for which the expectation
+            value is computed at every time value in ``t_save``.
         solver (SolverOption, optional): Solver used to compute the master equation
             solutions. See the list of available solvers.
         gradient_alg (str, optional): Algorithm used for computing gradients in the

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -27,9 +27,17 @@ def mesolve(
     """
     Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
 
-    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to solve multiple master equations in a single run. The jump operators `jump_ops` and time list `t_save` should however be common to all batches.
+    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to
+    solve multiple master equations in a single run. The jump operators `jump_ops` and
+    time list `t_save` should however be common to all batches.
 
-    The function can be differentiated over using either the default Pytorch autograd library (`gradient_alg="autograd"`), or a custom adjoint state differentiation (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward pass, such as a Rouchon solver, should be called. The parameters to compute the gradients with respect to should also be passed with the `parameters` argument. If differentiation is not required (`gradient_alg=None`), the graph of operation is not stored thus increasing the solver performance.
+    The function can be differentiated over using either the default Pytorch autograd
+    library (`gradient_alg="autograd"`), or a custom adjoint state differentiation
+    (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward
+    pass, such as a Rouchon solver, should be called. The parameters to compute the
+    gradients with respect to should also be passed with the `parameters` argument. If
+    differentiation is not required (`gradient_alg=None`), the graph of operation is
+    not stored thus increasing the solver performance.
 
     For time-dependent Hamiltonians, `H` can be TODO
 

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -58,15 +58,6 @@ def mesolve(
                 times, and of shape (len(exp_ops), len(t_save)) or
                 (b_H, b_rho, len(exp_ops), len(t_save)) if batched.
     """
-    # Args:
-    #     H: (b_H?, n, n)
-    #     rho0: (b_rho0?, n, n)
-    #
-    # Returns:
-    #     (y_save, exp_save) with
-    #     - y_save: (b_H?, b_rho0?, len(t_save), n, n)
-    #     - exp_save: (b_H?, b_rho0?, len(exp_ops), len(t_save))
-
     # batch H by default
     H_batched = H[None, ...] if H.dim() == 2 else H
 
@@ -99,7 +90,7 @@ def mesolve(
 
     # compute the result
     b_H = H_batched.size(0)
-    y0 = rho0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_rho0, n, n)
+    y0 = rho0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_rho, n, n)
     y_save, exp_save = odeint(qsolver, y0, t_save, exp_ops, save_states, gradient_alg)
 
     # restore correct batching
@@ -131,10 +122,10 @@ class MERouchon1(MERouchon):
     def forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1."""
         # Args:
-        #     rho: (b_H, b_rho0, n, n)
+        #     rho: (b_H, b_rho, n, n)
         #
         # Returns:
-        #     (b_H, b_rho0, n, n)
+        #     (b_H, b_rho, n, n)
 
         # non-hermitian Hamiltonian at time t
         H_nh = self.H - 0.5j * self.sum_nojump  # (b_H, 1, n, n)
@@ -159,10 +150,10 @@ class MERouchon1_5(MERouchon):
     def forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1.5."""
         # Args:
-        #     rho: (b_H, b_rho0, n, n)
+        #     rho: (b_H, b_rho, n, n)
         #
         # Returns:
-        #     (b_H, b_rho0, n, n)
+        #     (b_H, b_rho, n, n)
 
         # non-hermitian Hamiltonian at time t
         H_nh = self.H - 0.5j * self.sum_nojump  # (b_H, 1, n, n)
@@ -198,10 +189,10 @@ class MERouchon2(MERouchon):
         zero-th order Kraus operator if needed, as M0 += -0.5j * dt**2 * \dot{H}.
         """
         # Args:
-        #     rho: (b_H, b_rho0, n, n)
+        #     rho: (b_H, b_rho, n, n)
         #
         # Returns:
-        #     (b_H, b_rho0, n, n)
+        #     (b_H, b_rho, n, n)
 
         # non-hermitian Hamiltonian at time t
         H_nh = self.H - 0.5j * self.sum_nojump  # (b_H, 1, n, n)

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -27,9 +27,7 @@ def mesolve(
     """
     Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
 
-    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to
-    solve multiple master equations in a single run. The jump operators `jump_ops` and
-    time list `t_save` should however be common to all batches.
+    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to solve multiple master equations in a single run. The jump operators `jump_ops` and time list `t_save` should however be common to all batches.
 
     The function can be differentiated over using either the default Pytorch autograd library (`gradient_alg="autograd"`), or a custom adjoint state differentiation (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward pass, such as a Rouchon solver, should be called. The parameters to compute the gradients with respect to should also be passed with the `parameters` argument. If differentiation is not required (`gradient_alg=None`), the graph of operation is not stored thus increasing the solver performance.
 

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -41,9 +41,9 @@ def mesolve(
     passed as... TODO: complete with Hamiltonian format
 
     Available solvers:
-      - `Rouchon` (alias of `Rouchon2`)
-      - `Rouchon1`
+      - `Rouchon1` (alias of `Rouchon`)
       - `Rouchon1_5`
+      - `Rouchon2`
 
     Args:
         H (Tensor or Callable): Hamiltonian.

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Literal
 
 import torch
+from torch import Tensor
 from tqdm import tqdm
 
 from .solver import AdaptativeStep, FixedStep
@@ -10,7 +11,7 @@ from .solver_utils import bexpect
 
 class ForwardQSolver(ABC):
     @abstractmethod
-    def forward(self, t: float, dt: float, rho: torch.Tensor):
+    def forward(self, t: float, dt: float, rho: Tensor):
         # Args:
         #     rho: (..., m, n)
         #
@@ -21,17 +22,17 @@ class ForwardQSolver(ABC):
 
 class AdjointQSolver(ForwardQSolver):
     @abstractmethod
-    def forward_adjoint(self, t: float, dt: float, phi: torch.Tensor):
+    def forward_adjoint(self, t: float, dt: float, phi: Tensor):
         pass
 
 
 def odeint(
     qsolver: ForwardQSolver,
-    y0: torch.Tensor,
-    t_save: torch.Tensor,
-    exp_ops: torch.Tensor,
+    y0: Tensor,
+    t_save: Tensor,
+    exp_ops: Tensor,
     save_states: bool,
-    gradient_alg: Literal[None, 'autograd', 'adjoint'],
+    gradient_alg: Optional[Literal['autograd', 'adjoint']],
 ):
     # Args:
     #     y0: (..., m, n)
@@ -54,8 +55,8 @@ def odeint(
 
 
 def _odeint_main(
-    qsolver: ForwardQSolver, y0: torch.Tensor, t_save: torch.Tensor,
-    exp_ops: torch.Tensor, save_states: bool
+    qsolver: ForwardQSolver, y0: Tensor, t_save: Tensor, exp_ops: Tensor,
+    save_states: bool
 ):
     if isinstance(qsolver.options, FixedStep):
         return _fixed_odeint(
@@ -84,8 +85,8 @@ def _adaptive_odeint(*_args, **_kwargs):
 
 
 def _fixed_odeint(
-    qsolver: ForwardQSolver, y0: torch.Tensor, t_save: torch.Tensor, dt: float,
-    exp_ops: torch.Tensor, save_states: bool
+    qsolver: ForwardQSolver, y0: Tensor, t_save: Tensor, dt: float, exp_ops: Tensor,
+    save_states: bool
 ):
     # Args:
     #     y0: (..., m, n)
@@ -146,11 +147,11 @@ def _fixed_odeint(
     return y_save, exp_save
 
 
-def check_t_save(t_save: torch.Tensor):
+def check_t_save(t_save: Tensor):
     """Check that `t_save` is valid (it must be a non-empty 1D tensor sorted in
     strictly ascending order and containing only positive values)."""
     if t_save.dim() != 1 or len(t_save) == 0:
-        raise ValueError('Argument `t_save` must be a non-empty 1D torch.Tensor.')
+        raise ValueError('Argument `t_save` must be a non-empty 1D Tensor.')
     if not torch.all(torch.diff(t_save) > 0):
         raise ValueError(
             'Argument `t_save` must be sorted in strictly ascending order.'

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -151,7 +151,7 @@ def check_t_save(t_save: Tensor):
     """Check that `t_save` is valid (it must be a non-empty 1D tensor sorted in
     strictly ascending order and containing only positive values)."""
     if t_save.dim() != 1 or len(t_save) == 0:
-        raise ValueError('Argument `t_save` must be a non-empty 1D Tensor.')
+        raise ValueError('Argument `t_save` must be a non-empty 1D tensor.')
     if not torch.all(torch.diff(t_save) > 0):
         raise ValueError(
             'Argument `t_save` must be sorted in strictly ascending order.'

--- a/torchqdynamics/smesolve.py
+++ b/torchqdynamics/smesolve.py
@@ -2,19 +2,20 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch
+from torch import Tensor
 
 
 def smesolve(
-    H: torch.Tensor,
-    Ls: List[torch.Tensor],
-    Ms: List[torch.Tensor],
+    H: Tensor,
+    Ls: List[Tensor],
+    Ms: List[Tensor],
     etas: List[float],
-    rho0: torch.Tensor,
+    rho0: Tensor,
     tlist: np.ndarray,
     ntrajs: int,
     solver: str,
     options: Optional[Dict[str, Any]] = None,
-) -> torch.Tensor:
+) -> Tensor:
     raise NotImplementedError(
         'the Stochastic Master Equation solvers are not implemented yet, come '
         'back soon!'

--- a/torchqdynamics/solver_utils.py
+++ b/torchqdynamics/solver_utils.py
@@ -1,7 +1,8 @@
 import torch
+from torch import Tensor
 
 
-def kraus_map(rho: torch.Tensor, O: torch.Tensor) -> torch.Tensor:
+def kraus_map(rho: Tensor, O: Tensor) -> Tensor:
     """Compute the application of a Kraus map on an input density matrix.
 
     This is equivalent to `torch.sum(operators @ rho[None,...] @ operators.adjoint(),
@@ -18,7 +19,7 @@ def kraus_map(rho: torch.Tensor, O: torch.Tensor) -> torch.Tensor:
     return torch.einsum('abij,a...jk,abkl->a...il', O, rho, O.adjoint())
 
 
-def inv_sqrtm(mat: torch.Tensor) -> torch.Tensor:
+def inv_sqrtm(mat: Tensor) -> Tensor:
     """Compute the inverse square root of a matrix using its eigendecomposition.
 
     TODO: Replace with Schur decomposition once released by PyTorch.
@@ -31,7 +32,7 @@ def inv_sqrtm(mat: torch.Tensor) -> torch.Tensor:
     return vecs @ torch.linalg.solve(vecs, torch.diag(vals**(-0.5)), left=False)
 
 
-def bexpect(operators: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
+def bexpect(operators: Tensor, state: Tensor) -> Tensor:
     """Compute the expectation values of many operators on a quantum state or
     density matrix. The method is batchable over the operators and the state.
 

--- a/torchqdynamics/ssolve.py
+++ b/torchqdynamics/ssolve.py
@@ -2,15 +2,16 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import torch
+from torch import Tensor
 
 
 def ssolve(
-    H: torch.Tensor,
-    rho0: torch.Tensor,
+    H: Tensor,
+    rho0: Tensor,
     tlist: np.ndarray,
     solver: str,
     options: Optional[Dict[str, Any]] = None,
-) -> torch.Tensor:
+) -> Tensor:
     raise NotImplementedError(
         'the Schrödinger Master Equation solvers are not implemented yet, come '
         'back soon!'

--- a/torchqdynamics/types.py
+++ b/torchqdynamics/types.py
@@ -8,7 +8,7 @@ from torch import Tensor
 from .utils import from_qutip
 
 # TODO: add typing for Hamiltonian with piecewise-constant factor
-TensorTD = Union[Tensor, Callable[[float], Tensor]]
+TDOperator = Union[Tensor, Callable[[float], Tensor]]
 
 # type for objects convertible to a torch tensor using `torch.as_tensor`
 TensorLike = Union[List, np.ndarray, Tensor]

--- a/torchqdynamics/types.py
+++ b/torchqdynamics/types.py
@@ -3,20 +3,21 @@ from typing import Callable, List, Union, get_args
 import numpy as np
 import torch
 from qutip import Qobj
+from torch import Tensor
 
 from .utils import from_qutip
 
 # TODO: add typing for Hamiltonian with piecewise-constant factor
-TimeDependentOperator = Union[torch.Tensor, Callable[[float], torch.Tensor]]
+TensorTD = Union[Tensor, Callable[[float], Tensor]]
 
 # type for objects convertible to a torch tensor using `torch.as_tensor`
-TensorLike = Union[List, np.ndarray, torch.Tensor]
+TensorLike = Union[List, np.ndarray, Tensor]
 
 # type for objects convertible to a torch tensor using `torchqdynamics.to_tensor`
 QTensorLike = Union[TensorLike, Qobj]
 
 
-def to_torch(x: QTensorLike) -> torch.Tensor:
+def to_torch(x: QTensorLike) -> Tensor:
     """Convert a `QTensorLike` object to a PyTorch tensor.
 
     Args:

--- a/torchqdynamics/utils.py
+++ b/torchqdynamics/utils.py
@@ -2,9 +2,10 @@ from typing import List, Optional
 
 import torch
 from qutip import Qobj
+from torch import Tensor
 
 
-def ket_to_bra(x: torch.Tensor) -> torch.Tensor:
+def ket_to_bra(x: Tensor) -> Tensor:
     """Linear map (bra) representation of a state vector (ket).
 
     Args:
@@ -16,7 +17,7 @@ def ket_to_bra(x: torch.Tensor) -> torch.Tensor:
     return x.adjoint()
 
 
-def ket_to_dm(x: torch.Tensor) -> torch.Tensor:
+def ket_to_dm(x: Tensor) -> Tensor:
     """Density matrix formed by the outer product of a state vector (ket).
 
     Args:
@@ -28,7 +29,7 @@ def ket_to_dm(x: torch.Tensor) -> torch.Tensor:
     return x @ ket_to_bra(x)
 
 
-def ket_overlap(x: torch.Tensor, y: torch.Tensor) -> torch.complex:
+def ket_overlap(x: Tensor, y: Tensor) -> torch.complex:
     """Return the overlap (inner product) between two state vectors (kets).
 
     Args:
@@ -41,7 +42,7 @@ def ket_overlap(x: torch.Tensor, y: torch.Tensor) -> torch.complex:
     return (ket_to_bra(x) @ y).squeeze(-1).sum(-1)
 
 
-def ket_fidelity(x: torch.Tensor, y: torch.Tensor) -> float:
+def ket_fidelity(x: Tensor, y: Tensor) -> float:
     """Return the fidelity between two state vectors (kets).
 
     The fidelity between two pure states $\varphi$, $\psi$ is defined by their
@@ -64,7 +65,7 @@ def ket_fidelity(x: torch.Tensor, y: torch.Tensor) -> float:
     return ket_overlap(x, y).abs().pow(2)
 
 
-def dissipator(L: torch.Tensor, rho: torch.Tensor) -> torch.Tensor:
+def dissipator(L: Tensor, rho: Tensor) -> Tensor:
     """Apply the dissipation superoperator to a density matrix.
 
     The dissipation superoperator $\mathcal{D}[L](\cdot)$ is defined by
@@ -87,10 +88,10 @@ def dissipator(L: torch.Tensor, rho: torch.Tensor) -> torch.Tensor:
 
 
 def lindbladian(
-    H: torch.Tensor,
-    Ls: torch.Tensor,
-    rho: torch.Tensor,
-) -> torch.Tensor:
+    H: Tensor,
+    Ls: Tensor,
+    rho: Tensor,
+) -> Tensor:
     """Apply the Lindbladian superoperator to a density matrix.
 
     The system Lindbladian $\mathcal{L}(\cdot)$ is the superoperator
@@ -111,12 +112,12 @@ def lindbladian(
     return -1j * (H @ rho - rho @ H) + dissipator(Ls, rho).sum(0)
 
 
-def trace(rho: torch.Tensor) -> torch.Tensor:
+def trace(rho: Tensor) -> Tensor:
     """Compute the batched trace of a tensor over its last two dimensions."""
     return torch.einsum('...ii', rho)
 
 
-def expect(operator: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
+def expect(operator: Tensor, state: Tensor) -> Tensor:
     """Compute the expectation value of an operator on a quantum state or density
     matrix. The method is batchable over the state, but not over the operator.
 
@@ -131,7 +132,7 @@ def expect(operator: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
     return torch.einsum('ij,...ji', operator, state)
 
 
-def from_qutip(x: Qobj) -> torch.Tensor:
+def from_qutip(x: Qobj) -> Tensor:
     """Convert a QuTiP quantum object to a PyTorch tensor.
 
     Args:
@@ -143,7 +144,7 @@ def from_qutip(x: Qobj) -> torch.Tensor:
     return torch.from_numpy(x.full())
 
 
-def to_qutip(x: torch.Tensor, dims: Optional[List] = None) -> Qobj:
+def to_qutip(x: Tensor, dims: Optional[List] = None) -> Qobj:
     """Convert a PyTorch tensor to a QuTiP quantum object.
 
     Args:


### PR DESCRIPTION
Attempt at making `mesolve` more readable and less scary when reading the argument list for the first time. I renamed some types throughout the code, and added some documentation to `mesolve`. Plus some small modifications here and there overall aimed at improving readability. For the docstring, I tried to be complete but concise, and followed the Pytorch format (see e.g. [torch.autograd.grad](https://github.com/pytorch/pytorch/blob/c757647dd8c198fbcca4d4e6c7cba6f1d12b97e6/torch/autograd/__init__.py#L208)).

IMO, the main question you should ask yourself when reviewing this PR is: does this improve the readability of the code for someone looking at it for the first time, with no prior knowledge of the library?

I think this is important for people that are considering adopting tqd instead of qutip.