### PR TITLE
Implement adjoint autodiff for `mesolve`

### DIFF
--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -139,9 +139,6 @@ class MERouchon(AdjointQSolver):
         self.I = torch.eye(self.n).to(H)  # (n, n)
         self.options = solver_options
 
-        # reference time, default to 0.0
-        self.t0 = 0.0
-
 
 class MERouchon1(MERouchon):
     def forward(self, t: float, dt: float, rho: Tensor):

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -112,7 +112,7 @@ def mesolve(
 
     # compute the result
     rho_save, exp_save = odeint(
-        qsolver, rho0_batched, t_save, exp_ops, save_states, gradient_alg
+        qsolver, rho0_batched, t_save, exp_ops, save_states, gradient_alg, parameters
     )
 
     # restore correct batching
@@ -141,7 +141,7 @@ class MERouchon(AdjointQSolver):
 
 
 class MERouchon1(MERouchon):
-    def forward(self, t: float, dt: float, rho: Tensor):
+    def _forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1."""
         # Args:
         #     rho: (b_H, b_rho, n, n)
@@ -164,12 +164,14 @@ class MERouchon1(MERouchon):
 
         return rho
 
-    def forward_adjoint(self, t: float, dt: float, phi: Tensor):
-        raise NotImplementedError
+    def _backward_augmented(
+        self, t: float, dt: float, aug_rho: Tensor, parameters: Tuple[nn.Parameter, ...]
+    ):
+        pass
 
 
 class MERouchon1_5(MERouchon):
-    def forward(self, t: float, dt: float, rho: Tensor):
+    def _forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1.5."""
         # Args:
         #     rho: (b_H, b_rho, n, n)
@@ -198,12 +200,14 @@ class MERouchon1_5(MERouchon):
 
         return rho
 
-    def forward_adjoint(self, t: float, dt: float, phi: Tensor):
-        raise NotImplementedError
+    def _backward_augmented(
+        self, t: float, dt: float, aug_rho: Tensor, parameters: Tuple[nn.Parameter, ...]
+    ):
+        pass
 
 
 class MERouchon2(MERouchon):
-    def forward(self, t: float, dt: float, rho: Tensor):
+    def _forward(self, t: float, dt: float, rho: Tensor):
         r"""Compute rho(t+dt) using a Rouchon method of order 2.
 
         Note:
@@ -236,5 +240,7 @@ class MERouchon2(MERouchon):
 
         return rho
 
-    def forward_adjoint(self, t: float, dt: float, phi: Tensor):
-        raise NotImplementedError
+    def _backward_augmented(
+        self, t: float, dt: float, aug_rho: Tensor, parameters: Tuple[nn.Parameter, ...]
+    ):
+        pass

--- a/torchqdynamics/mesolve.py
+++ b/torchqdynamics/mesolve.py
@@ -236,7 +236,7 @@ class MERouchon1_5(MERouchon):
     def _backward_augmented(
         self, t: float, dt: float, aug_rho: Tensor, parameters: Tuple[nn.Parameter, ...]
     ):
-        pass
+        raise NotImplementedError
 
 
 class MERouchon2(MERouchon):
@@ -276,4 +276,38 @@ class MERouchon2(MERouchon):
     def _backward_augmented(
         self, t: float, dt: float, aug_rho: Tensor, parameters: Tuple[nn.Parameter, ...]
     ):
-        pass
+        """Compute augmented_rho(t-dt) using a Rouchon method of order 2."""
+        rho = aug_rho[0][0].requires_grad_(True)
+        phi = aug_rho[0][1].requires_grad_(True)
+        grad = aug_rho[1]
+
+        with torch.enable_grad():
+            # non-hermitian Hamiltonian at time (t0 - t)
+            # TODO: When time-dependent Hamiltonians are implemented, the Hamiltonian
+            #       should be computed at time `self.t0 - t`.
+            H_nh = self.H - 0.5j * self.sum_nojump
+            Hdag_nh = H_nh.adjoint()
+
+            # compute rho(t-dt)
+            M0 = self.I + 1j * dt * H_nh - 0.5 * dt**2 * H_nh @ H_nh
+            M1s = 0.5 * sqrt(dt) * (self.jump_ops @ M0 + M0 @ self.jump_ops)
+            tmp = kraus_map(rho, M1s)
+            rho = kraus_map(rho, M0) - tmp + 0.5 * kraus_map(tmp, M1s)
+            rho = rho / trace(rho)[..., None, None].real
+
+            # compute phi(t-dt)
+            M0_adj = self.I + 1j * dt * Hdag_nh - 0.5 * dt**2 * Hdag_nh @ Hdag_nh
+            M1s_adj = 0.5 * sqrt(dt) * (
+                self.jump_ops.adjoint() @ M0_adj + M0_adj @ self.jump_ops.adjoint()
+            )
+            tmp = kraus_map(phi, M1s_adj)
+            phi = (kraus_map(phi, M0_adj) + tmp + 0.5 * kraus_map(tmp, M1s_adj))
+
+            # compute grad(t-dt)
+            dgrad = torch.autograd.grad(
+                phi, parameters, rho, allow_unused=True, retain_graph=True
+            )
+            dgrad = none_to_zeros_like(dgrad, parameters)
+            grad = tuple(dg + g for dg, g in zip(dgrad, grad))
+
+        return (torch.stack((rho, phi)), grad)

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -151,6 +151,7 @@ def _odeint_adjoint(
     qsolver: AdjointQSolver, y0: Tensor, t_save: Tensor, exp_ops: Tensor,
     save_states: bool, parameters: Tuple[nn.Parameter, ...]
 ):
+    """Integrate an ODE using the adjoint method in the backward pass."""
     return ODEIntAdjoint.apply(qsolver, y0, t_save, exp_ops, save_states, *parameters)
 
 
@@ -158,6 +159,7 @@ def _odeint_augmented_main(
     qsolver: AdjointQSolver, y0: Tensor, a0: Tensor, g0: Tuple[Tensor, ...],
     t_span: Tensor, parameters: Tuple[nn.Parameter, ...]
 ):
+    """Integrate the augmented ODE backward."""
     if isinstance(qsolver.options, FixedStep):
         dt = qsolver.options.dt
         return _fixed_odeint_augmented(qsolver, y0, a0, g0, t_span, dt, parameters)
@@ -166,6 +168,7 @@ def _odeint_augmented_main(
 
 
 def _adaptive_odeint_augmented(*_args, **_kwargs):
+    """Integrate the augmented ODE backward using an adaptive time step solver."""
     raise NotImplementedError
 
 
@@ -173,6 +176,7 @@ def _fixed_odeint_augmented(
     qsolver: AdjointQSolver, y0: Tensor, a0: Tensor, g0: Tuple[Tensor, ...],
     t_span: Tensor, dt: float, parameters: Tuple[nn.Parameter, ...]
 ):
+    """Integrate the augmented ODE backward using a fixed time step solver."""
     # check t_span
     if not (t_span.ndim == 1 and len(t_span) == 2):
         raise ValueError(
@@ -207,7 +211,7 @@ def _fixed_odeint_augmented(
 
 
 class ODEIntAdjoint(torch.autograd.Function):
-    """ODE integrator with a custom adjoint method backward pass."""
+    """Class for ODE integration with a custom adjoint method backward pass."""
     @staticmethod
     def forward(ctx, qsolver, y0, t_save, exp_ops, save_states, *parameters):
         """Forward pass of the ODE integrator."""

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import ABC, abstractmethod
-from typing import Literal
+from typing import Literal, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -203,7 +203,6 @@ class ODEIntAdjoint(torch.autograd.Function):
         # unpack context
         qsolver = ctx.qsolver
         t_save = ctx.t_save
-        save_states = ctx.save_states
         y_save, *parameters = ctx.saved_tensors
 
         # prepare checkpoints time list

--- a/torchqdynamics/solver_utils.py
+++ b/torchqdynamics/solver_utils.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import torch
 from torch import Tensor
 
@@ -53,3 +55,8 @@ def none_to_zeros_like(input, shaping_tuple):
     return tuple(
         torch.zeros_like(s) if a is None else a for a, s in zip(input, shaping_tuple)
     )
+
+
+def add_tuples(a: Tuple, b: Tuple):
+    """Element-wise sum of two tuples of the same shape."""
+    return tuple(map(sum, zip(a, b)))

--- a/torchqdynamics/solver_utils.py
+++ b/torchqdynamics/solver_utils.py
@@ -45,3 +45,11 @@ def bexpect(operators: Tensor, state: Tensor) -> Tensor:
     # TODO: Once QTensor is implemented, check if state is a density matrix or ket.
     # For now, we assume it is a density matrix.
     return torch.einsum('bij,...ji->...b', operators, state)
+
+
+def none_to_zeros_like(input, shaping_tuple):
+    """Convert None values of an input tuple to zero-valued tensors with the same shape
+    as shaping_tuple."""
+    return tuple(
+        torch.zeros_like(s) if a is None else a for a, s in zip(input, shaping_tuple)
+    )

--- a/torchqdynamics/utils.py
+++ b/torchqdynamics/utils.py
@@ -43,7 +43,7 @@ def ket_overlap(x: Tensor, y: Tensor) -> torch.complex:
 
 
 def ket_fidelity(x: Tensor, y: Tensor) -> float:
-    """Return the fidelity between two state vectors (kets).
+    r"""Return the fidelity between two state vectors (kets).
 
     The fidelity between two pure states $\varphi$, $\psi$ is defined by their
     squared overlap
@@ -66,7 +66,7 @@ def ket_fidelity(x: Tensor, y: Tensor) -> float:
 
 
 def dissipator(L: Tensor, rho: Tensor) -> Tensor:
-    """Apply the dissipation superoperator to a density matrix.
+    r"""Apply the dissipation superoperator to a density matrix.
 
     The dissipation superoperator $\mathcal{D}[L](\cdot)$ is defined by
     $$
@@ -92,7 +92,7 @@ def lindbladian(
     Ls: Tensor,
     rho: Tensor,
 ) -> Tensor:
-    """Apply the Lindbladian superoperator to a density matrix.
+    r"""Apply the Lindbladian superoperator to a density matrix.
 
     The system Lindbladian $\mathcal{L}(\cdot)$ is the superoperator
     generating the evolution of the system. It is defined by


### PR DESCRIPTION
I suggest reviewing commit by commit. 

I am not happy about everything, but the main idea is here. In particular, I'm not sure about commit c04e4b289d23d7e3ad56c715730f441ff7c7f500 and the `QSolver` organization (with the flag inside `ODEIntAdjoint.backward`). I'm down for suggestions.

Also I have not tested it, so a few bugs here and there might remain. But I've got a similar implementation for my own project that works. I will write a test function at some point.

---

EDIT: I have refactored the code in a better way. I'm now much more happy with the implementation. Instead of the backward pass going back into `odeint_main`, it now has a dedicated backward ode integrator. It helps a lot readability, but also avoids overloading the various `odeint` functions.

When calling `odeint(..., gradient_alg='adjoint',...)`, the following calls are sequentially made:
 - **Forward pass**: `odeint` --> `_odeint_adjoint` --> `ODEIntAdjoint.forward` --> `_odeint_inplace` --> `_odeint_main` --> `_fixed_odeint`/`_adaptive_odeint` --> `qsolver.forward`
 - **Backward pass**: `odeint` --> `_odeint_adjoint` --> `ODEIntAdjoint.backward` --> `_odeint_augmented_main` --> `_fixed_odeint_augmented`/`_adaptive_odeint_augmented` --> `qsolver.backward_augmented`

For reviewing, it might now be better to look at all commits at once, and to start from `odeint.py` before reading `mesolve.py`.

