### PR TITLE
Clean up code and minimal documentation for odeint/mesolve

### DIFF
--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -5,6 +5,7 @@ from typing import Literal, Optional, Tuple
 import torch
 import torch.nn as nn
 from torch import Tensor
+from torch.autograd.function import FunctionCtx
 from tqdm.auto import tqdm
 
 from .solver import AdaptativeStep, FixedStep
@@ -13,32 +14,60 @@ from .solver_utils import add_tuples, bexpect, none_to_zeros_like
 
 class ForwardQSolver(ABC):
     @abstractmethod
-    def forward(self, t: float, dt: float, y: Tensor):
-        # Args:
-        #     y: (..., m, n)
-        #
-        # Returns:
-        #     (..., m, n)
+    def forward(self, t: float, y: Tensor) -> Tensor:
+        """Iterate the quantum state forward.
+
+        Args:
+            t (float): Time.
+            y (Tensor): Quantum state, of shape (..., m, n).
+
+        Returns:
+            Tensor of shape (..., m, n).
+        """
         pass
 
 
 class AdjointQSolver(ForwardQSolver):
     @abstractmethod
     def backward_augmented(
-        self, t: float, dt: float, y: Tensor, a: Tensor, parameters: Tuple[nn.Parameter,
-                                                                           ...]
-    ):
+        self, t: float, y: Tensor, a: Tensor, parameters: Tuple[nn.Parameter, ...]
+    ) -> Tuple[Tensor, Tensor]:
+        """Iterate the augmented quantum state backward.
+
+        Args:
+            t (float): Time.
+            y (Tensor): Quantum state, of shape (..., m, n).
+            a (Tensor): Adjoint quantum state, of shape (..., m, n).
+            parameters (tuple of nn.Parameter): Parameters w.r.t. compute the gradients.
+
+        Returns:
+            Tuple of two tensors of shape (..., m, n).
+        """
         pass
 
 
 def odeint(
-    qsolver: ForwardQSolver, y0: Tensor, t_save: Tensor, exp_ops: Tensor,
-    save_states: bool, gradient_alg: Optional[Literal['autograd', 'adjoint']],
+    qsolver: ForwardQSolver, y0: Tensor, t_save: Tensor, *, save_states: bool,
+    exp_ops: Tensor, gradient_alg: Optional[Literal['autograd', 'adjoint']],
     parameters: Optional[Tuple[nn.Parameter, ...]]
-):
-    # Args:
-    #     y0: (..., m, n)
+) -> Tuple[Tensor, Tensor]:
+    """Integrate a quantum ODE starting from an initial state.
 
+    Args:
+        qsolver ():
+        y0 (Tensor): Initial quantum state, of shape (..., m, n).
+        t_save (Tensor): Times for which results are saved. The ODE is solved from
+            time `t=0.0` to `t=t_save[-1]`.
+        save_states ():
+        exp_ops ():
+        gradient_alg ():
+        parameters ():
+
+    Returns:
+        Tuple `(y_save, exp_save)` with
+            - `y_save` a tensor of shape (..., len(t_save), m, n)
+            - `exp_save` a tensor of shape (..., len(exp_ops), len(t_save))
+    """
     # check arguments
     check_t_save(t_save)
 
@@ -47,7 +76,7 @@ def odeint(
         warnings.warn('Parameters were supplied in `odeint` but not used.')
 
     # dispatch to appropriate odeint subroutine
-    args = (qsolver, y0, t_save, exp_ops, save_states)
+    args = (qsolver, y0, t_save, save_states, exp_ops)
     if gradient_alg is None:
         return _odeint_inplace(*args)
     elif gradient_alg == 'autograd':
@@ -61,44 +90,56 @@ def odeint(
 
 
 def _odeint_main(
-    qsolver: ForwardQSolver, y0: Tensor, t_save: Tensor, exp_ops: Tensor,
-    save_states: bool
-):
+    qsolver: ForwardQSolver, y0: Tensor, t_save: Tensor, save_states: bool,
+    exp_ops: Tensor
+) -> Tuple[Tensor, Tensor]:
+    """Dispatch the ODE integration to fixed or adaptive time step subroutines."""
     if isinstance(qsolver.options, FixedStep):
-        dt = qsolver.options.dt
-        return _fixed_odeint(qsolver, y0, t_save, dt, exp_ops, save_states)
+        return _fixed_odeint(qsolver, y0, t_save, save_states, exp_ops)
     elif isinstance(qsolver.options, AdaptativeStep):
-        return _adaptive_odeint(qsolver, y0, t_save, exp_ops, save_states)
+        return _adaptive_odeint(qsolver, y0, t_save, save_states, exp_ops)
 
 
-# For now we use *args and **kwargs for helper methods that are not implemented to ease
-# the potential api changes that could occur later. When a method is implemented the
-# methods should take the same arguments as all others.
 def _odeint_inplace(*args, **kwargs):
-    # TODO: Simple solution for now so torch does not store gradients. This
-    #       is probably slower than a genuine in-place solver.
+    """Integrate a quantum ODE with an in-place solver.
+
+    Simple solution for now so torch does not store gradients.
+    TODO Implement a genuine in-place solver.
+    """
     with torch.no_grad():
         return _odeint_main(*args, **kwargs)
 
 
 def _adaptive_odeint(*_args, **_kwargs):
+    """Integrate a quantum ODE with an adapative time step solver."""
     raise NotImplementedError
 
 
 def _fixed_odeint(
-    qsolver: ForwardQSolver, y0: Tensor, t_save: Tensor, dt: float, exp_ops: Tensor,
-    save_states: bool
-):
-    # Args:
-    #     y0: (..., m, n)
-    #
-    # Returns:
-    #     (y_save, exp_save) with
-    #     - y_save: (..., len(t_save), m, n)
-    #     - exp_save: (..., len(exp_ops), len(t_save))
+    qsolver: ForwardQSolver, y0: Tensor, t_save: Tensor, save_states: bool,
+    exp_ops: Tensor
+) -> Tuple[Tensor, Tensor]:
+    """Integrate a quantum ODE with a fixed time step solver.
 
-    # assert that `t_save` values are multiples of `dt` (with the default
-    # `rtol=1e-5` they differ by at most 0.001% from a multiple of `dt`)
+    Note:
+        The solver times are defined using `torch.linspace` which ensures that the overall solution is evolved from the user-defined time (up to an error of `rtol=1e-5`). However, this may induce a small mismatch between the time step inside `qsolver` and the time step inside the iteration loop. A small error can thus buildup throughout the ODE integration. TODO Fix this.
+
+    Args:
+        qsolver ():
+        y0 (): Initial quantum state, of shape (..., m, n).
+        t_save ():
+        save_states ():
+        exp_ops ():
+
+    Returns:
+        Tuple `(y_save, exp_save)` with
+            - `y_save` a tensor of shape (..., len(t_save), m, n)
+            - `exp_save` a tensor of shape (..., len(exp_ops), len(t_save))
+    """
+    # get time step from qsolver
+    dt = qsolver.options.dt
+
+    # assert that `t_save` values are multiples of `dt`
     if not torch.allclose(torch.round(t_save / dt), t_save / dt):
         raise ValueError(
             'Every value of argument `t_save` must be a multiple of the time step `dt`.'
@@ -114,13 +155,6 @@ def _fixed_odeint(
         exp_save = torch.zeros(*batch_sizes, len(exp_ops), len(t_save)).to(y0)
 
     # define time values
-    # Note that defining the solver times as `torch.arange(0.0, t_save[-1], dt)`
-    # could result in an error of order `dt` in the save time (e.g. for
-    # `t_save[-1]=1.0` and `dt=0.999999` -> `times=[0.000000, 0.999999]`, so
-    # the final state would be saved one time step too far at
-    # `0.999999 + dt ~ 2.0`). The previous definition ensures that we never
-    # perform an extra step, so the error on the correct save time is of
-    # `0.001% * dt` instead of `dt`.
     times = torch.linspace(0.0, t_save[-1], torch.round(t_save[-1] / dt).int() + 1)
 
     # run the ode routine
@@ -136,7 +170,7 @@ def _fixed_odeint(
             save_counter += 1
 
         # iterate solution
-        y = qsolver.forward(t, dt, y)
+        y = qsolver.forward(t, y)
 
     # save final time step (`t` goes `0.0` to `t_save[-1]` excluded)
     if save_states:
@@ -148,21 +182,20 @@ def _fixed_odeint(
 
 
 def _odeint_adjoint(
-    qsolver: AdjointQSolver, y0: Tensor, t_save: Tensor, exp_ops: Tensor,
-    save_states: bool, parameters: Tuple[nn.Parameter, ...]
-):
+    qsolver: AdjointQSolver, y0: Tensor, t_save: Tensor, save_states: bool,
+    exp_ops: Tensor, parameters: Tuple[nn.Parameter, ...]
+) -> Tuple[Tensor, Tensor]:
     """Integrate an ODE using the adjoint method in the backward pass."""
-    return ODEIntAdjoint.apply(qsolver, y0, t_save, exp_ops, save_states, *parameters)
+    return ODEIntAdjoint.apply(qsolver, y0, t_save, save_states, exp_ops, *parameters)
 
 
 def _odeint_augmented_main(
     qsolver: AdjointQSolver, y0: Tensor, a0: Tensor, g0: Tuple[Tensor, ...],
     t_span: Tensor, parameters: Tuple[nn.Parameter, ...]
-):
+) -> Tuple[Tensor, Tensor]:
     """Integrate the augmented ODE backward."""
     if isinstance(qsolver.options, FixedStep):
-        dt = qsolver.options.dt
-        return _fixed_odeint_augmented(qsolver, y0, a0, g0, t_span, dt, parameters)
+        return _fixed_odeint_augmented(qsolver, y0, a0, g0, t_span, parameters)
     elif isinstance(qsolver.options, AdaptativeStep):
         return _adaptive_odeint_augmented(qsolver, y0, a0, g0, t_span, parameters)
 
@@ -174,9 +207,12 @@ def _adaptive_odeint_augmented(*_args, **_kwargs):
 
 def _fixed_odeint_augmented(
     qsolver: AdjointQSolver, y0: Tensor, a0: Tensor, g0: Tuple[Tensor, ...],
-    t_span: Tensor, dt: float, parameters: Tuple[nn.Parameter, ...]
-):
+    t_span: Tensor, parameters: Tuple[nn.Parameter, ...]
+) -> Tuple[Tensor, Tensor, Tuple[Tensor, ...]]:
     """Integrate the augmented ODE backward using a fixed time step solver."""
+    # get time step from qsolver
+    dt = qsolver.options.dt
+
     # check t_span
     if not (t_span.ndim == 1 and len(t_span) == 2):
         raise ValueError(
@@ -198,7 +234,7 @@ def _fixed_odeint_augmented(
     for t in tqdm(times[:-1], leave=False):
         with torch.enable_grad():
             # compute y(t-dt) and a(t-dt) with the qsolver
-            y, a = qsolver.backward_augmented(t, dt, y, a, parameters)
+            y, a = qsolver.backward_augmented(t, y, a, parameters)
 
             # compute g(t-dt)
             dg = torch.autograd.grad(
@@ -213,14 +249,17 @@ def _fixed_odeint_augmented(
 class ODEIntAdjoint(torch.autograd.Function):
     """Class for ODE integration with a custom adjoint method backward pass."""
     @staticmethod
-    def forward(ctx, qsolver, y0, t_save, exp_ops, save_states, *parameters):
+    def forward(
+        ctx: FunctionCtx, qsolver: AdjointQSolver, y0: Tensor, t_save: Tensor,
+        save_states: bool, exp_ops: Tensor, *parameters: Tuple[nn.Parameter, ...]
+    ) -> Tuple[Tensor, Tensor]:
         """Forward pass of the ODE integrator."""
         # save into context for backward pass
         ctx.qsolver = qsolver
         ctx.t_save = t_save if save_states else t_save[-1]
 
         # solve the ODE forward without storing the graph of operations
-        y_save, exp_save = _odeint_inplace(qsolver, y0, t_save, exp_ops, save_states)
+        y_save, exp_save = _odeint_inplace(qsolver, y0, t_save, save_states, exp_ops)
 
         # save results and model parameters
         ctx.save_for_backward(y_save, *parameters)
@@ -228,7 +267,7 @@ class ODEIntAdjoint(torch.autograd.Function):
         return y_save, exp_save
 
     @staticmethod
-    def backward(ctx, *grad_y):
+    def backward(ctx: FunctionCtx, *grad_y: Tensor):
         """Backward pass of the ODE integrator.
 
         An augmented ODE is integrated backwards starting from the final state computed
@@ -240,8 +279,8 @@ class ODEIntAdjoint(torch.autograd.Function):
         and `g = dL/dp` is the gradient w.r.t. the parameters, where `L` is the loss
         function and `p` the parameters.
 
-        TODO: Check that stacking `y` and `a` does not improve performance of the
-        solver. There was funky stuff happening in this regard in some tests I ran.
+        TODO Check that stacking `y` and `a` does not improve performance of the
+             solver. There was funky stuff happening in this regard in some tests I ran.
         """
         # disable gradient computation
         torch.set_grad_enabled(False)

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -122,7 +122,11 @@ def _fixed_odeint(
     """Integrate a quantum ODE with a fixed time step solver.
 
     Note:
-        The solver times are defined using `torch.linspace` which ensures that the overall solution is evolved from the user-defined time (up to an error of `rtol=1e-5`). However, this may induce a small mismatch between the time step inside `qsolver` and the time step inside the iteration loop. A small error can thus buildup throughout the ODE integration. TODO Fix this.
+        The solver times are defined using `torch.linspace` which ensures that the
+        overall solution is evolved from the user-defined time (up to an error of
+        `rtol=1e-5`). However, this may induce a small mismatch between the time step
+        inside `qsolver` and the time step inside the iteration loop. A small error can
+        thus buildup throughout the ODE integration. TODO Fix this.
 
     Args:
         qsolver ():

--- a/torchqdynamics/solver_utils.py
+++ b/torchqdynamics/solver_utils.py
@@ -11,24 +11,24 @@ def kraus_map(rho: Tensor, O: Tensor) -> Tensor:
     dim=0)`. The use of einsum yields better performances on large matrices, but may
     cause a small overhead on smaller matrices (N <~ 50).
 
+    TODO Fix documentation
+
     Args:
         rho: Density matrix of shape (a, ..., n, n).
         operators: Kraus operators of shape (a, b, n, n).
     Returns:
         Density matrix of shape (a, ..., n, n) with the Kraus map applied.
     """
-    # TODO: fix doc
     return torch.einsum('abij,a...jk,abkl->a...il', O, rho, O.adjoint())
 
 
 def inv_sqrtm(mat: Tensor) -> Tensor:
     """Compute the inverse square root of a matrix using its eigendecomposition.
 
-    TODO: Replace with Schur decomposition once released by PyTorch.
-    See the feature request at https://github.com/pytorch/pytorch/issues/78809.
-    Alternatively, see
-    https://github.com/pytorch/pytorch/issues/25481#issuecomment-584896176
-    for sqrtm implementation.
+    TODO Replace with Schur decomposition once released by PyTorch.
+         See the feature request at https://github.com/pytorch/pytorch/issues/78809.
+         Alternatively, see a sqrtm implementation at
+         https://github.com/pytorch/pytorch/issues/25481#issuecomment-584896176.
     """
     vals, vecs = torch.linalg.eigh(mat)
     return vecs @ torch.linalg.solve(vecs, torch.diag(vals**(-0.5)), left=False)
@@ -38,25 +38,27 @@ def bexpect(operators: Tensor, state: Tensor) -> Tensor:
     """Compute the expectation values of many operators on a quantum state or
     density matrix. The method is batchable over the operators and the state.
 
+    TODO Adapt to both density matrices, kets and bras.
     Args:
         operators: tensor of shape (b, n, n)
         state: tensor of shape (..., n, n) or (..., n)
     Returns:
         expectation value of shape (..., m)
     """
-    # TODO: Once QTensor is implemented, check if state is a density matrix or ket.
-    # For now, we assume it is a density matrix.
     return torch.einsum('bij,...ji->...b', operators, state)
 
 
-def none_to_zeros_like(input, shaping_tuple):
-    """Convert None values of an input tuple to zero-valued tensors with the same shape
-    as shaping_tuple."""
+def none_to_zeros_like(
+    in_tuple: Tuple[Union[Tensor, None], ...], shaping_tuple: Tuple[Tensor, ...]
+) -> Tuple[Tensor, ...]:
+    """Convert None values of `in_tuple` to zero-valued tensors with the same shape
+    as `shaping_tuple`."""
     return tuple(
-        torch.zeros_like(s) if a is None else a for a, s in zip(input, shaping_tuple)
+        torch.zeros_like(s) if a is None else a
+        for a, s in zip(in_tuple, shaping_tuple)
     )
 
 
-def add_tuples(a: Tuple, b: Tuple):
+def add_tuples(a: Tuple, b: Tuple) -> Tuple:
     """Element-wise sum of two tuples of the same shape."""
     return tuple(map(sum, zip(a, b)))

--- a/torchqdynamics/types.py
+++ b/torchqdynamics/types.py
@@ -7,7 +7,7 @@ from torch import Tensor
 
 from .utils import from_qutip
 
-# TODO: add typing for Hamiltonian with piecewise-constant factor
+# TODO Add typing for Hamiltonian with piecewise-constant factor
 TDOperator = Union[Tensor, Callable[[float], Tensor]]
 
 # type for objects convertible to a torch tensor using `torch.as_tensor`


### PR DESCRIPTION
A little bit of clean up and documentation.

Also, I removed the argument `dt` accross various `_odeint` functions, since the time step should be private to the qsolver (the fixed odeint subroutine never changes the value of `dt` called). It also makes the `qsolver.forward` functions signature consistent between fixed and adaptive solvers (see next PR).