### PR TITLE
Rename types and begin mesolve documentation

### DIFF
--- a/torchqdynamics/mesolve/mesolve.py
+++ b/torchqdynamics/mesolve/mesolve.py
@@ -2,6 +2,7 @@ from typing import List, Literal, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from torch import Tensor
 
 from ..odeint import odeint
 from ..solver_options import SolverOption
@@ -17,20 +18,71 @@ def mesolve(
     rho0: OperatorLike,
     t_save: TensorLike,
     *,
-    exp_ops: Optional[List[OperatorLike]] = None,
     save_states: bool = True,
+    exp_ops: Optional[List[OperatorLike]] = None,
+    solver: Optional[SolverOption] = None,
     gradient_alg: Optional[Literal['autograd', 'adjoint']] = None,
     parameters: Optional[Tuple[nn.Parameter, ...]] = None,
-    solver: Optional[SolverOption] = None,
-):
-    # Args:
-    #     H: (b_H?, n, n)
-    #     rho0: (b_rho0?, n, n)
-    #
-    # Returns:
-    #     (y_save, exp_save) with
-    #     - y_save: (b_H?, b_rho0?, len(t_save), n, n)
-    #     - exp_save: (b_H?, b_rho0?, len(exp_ops), len(t_save))
+) -> Tuple[Tensor, Tensor]:
+    """Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
+
+    The Hamiltonian `H` and the initial density matrix `rho0` can be batched over to
+    solve multiple master equations in a single run. The jump operators `jump_ops` and
+    time list `t_save` are common to all batches.
+
+    `mesolve` can be differentiated through using either the default PyTorch autograd
+    library (`gradient_alg="autograd"`), or a custom adjoint state differentiation
+    (`gradient_alg="adjoint"`). For the latter, a solver that is stable in the backward
+    pass should be used (e.g. Rouchon solver). By default (if no gradient is required),
+    the graph of operations is not stored for improved performance of the solver.
+
+    For time-dependent problems, the Hamiltonian `H` can be passed as a function with
+    signature `H(t: float) -> Tensor`. Piecewise constant Hamiltonians can also be
+    passed as... TODO: complete with Hamiltonian format
+
+    Available solvers:
+      - `Rouchon1` (alias of `Rouchon`)
+      - `Rouchon1_5`
+      - `Rouchon2`
+
+    Args:
+        H (Tensor or Callable): Hamiltonian.
+            Can be a tensor of shape (n, n) or (b_H, n, n) if batched, or a callable
+            `H(t: float) -> Tensor` that returns a tensor of either possible shapes
+            at every time between `t=0` and `t=t_save[-1]`.
+        jump_ops (list of Tensor): List of jump operators.
+            Each jump operator should be a tensor of shape (n, n).
+        rho0 (Tensor): Initial density matrix.
+            Tensor of shape (n, n) or (b_rho, n, n) if batched.
+        t_save (Tensor, np.ndarray or list): Times for which results are saved.
+            The master equation is solved from time `t=0.0` to `t=t_save[-1]`.
+        save_states (bool, optional): If `True`, the density matrix is saved at every
+            time value in `t_save`. If `False`, only the final density matrix is
+            stored and returned. Defaults to `True`.
+        exp_ops (list of Tensor, optional): List of operators for which the expectation
+            value is computed at every time value in `t_save`.
+        solver (SolverOption, optional): Solver used to compute the master equation
+            solutions. See the list of available solvers.
+        gradient_alg (str, optional): Algorithm used for computing gradients in the
+            backward pass. Defaults to `None`.
+        parameters (tuple of nn.Parameter): Parameters with respect to which gradients
+            are computed during the adjoint state backward pass.
+
+    Returns:
+        A tuple `(rho_save, exp_save)` where
+            `rho_save` is a tensor with the computed density matrices at `t_save`
+                times, and of shape (len(t_save), n, n) or (b_H, b_rho, len(t_save), n,
+                n) if batched. If `save_states` is `False`, only the final density
+                matrix is returned with the same shape as the initial input.
+            `exp_save` is a tensor with the computed expectation values at `t_save`
+                times, and of shape (len(exp_ops), len(t_save)) or (b_H, b_rho,
+                len(exp_ops), len(t_save)) if batched.
+    """
+    # H: (b_H?, n, n)
+    # rho0: (b_rho0?, n, n)
+    # -> (rho_save, exp_save) with
+    #   - rho_save: (b_H?, b_rho0?, len(t_save), n, n)
+    #   - exp_save: (b_H?, b_rho0?, len(exp_ops), len(t_save))
 
     # TODO: H is assumed to be time-independent from here (temporary)
 
@@ -47,7 +99,9 @@ def mesolve(
     rho0 = to_tensor(rho0)
     if is_ket(rho0):
         rho0 = ket_to_dm(rho0)
+    b_H = H_batched.size(0)
     rho0_batched = rho0[None, ...] if rho0.dim() == 2 else rho0
+    rho0_batched = rho0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_rho0, n, n)
 
     t_save = torch.as_tensor(t_save)
 
@@ -68,16 +122,16 @@ def mesolve(
         raise NotImplementedError
 
     # compute the result
-    b_H = H_batched.size(0)
-    y0 = rho0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_rho0, n, n)
-    y_save, exp_save = odeint(qsolver, y0, t_save, exp_ops, save_states, gradient_alg)
+    rho_save, exp_save = odeint(
+        qsolver, rho0_batched, t_save, exp_ops, save_states, gradient_alg
+    )
 
     # restore correct batching
     if rho0.dim() == 2:
-        y_save = y_save.squeeze(1)
+        rho_save = rho_save.squeeze(1)
         exp_save = exp_save.squeeze(1)
     if H.dim() == 2:
-        y_save = y_save.squeeze(0)
+        rho_save = rho_save.squeeze(0)
         exp_save = exp_save.squeeze(0)
 
-    return y_save, exp_save
+    return rho_save, exp_save

--- a/torchqdynamics/mesolve/mesolve.py
+++ b/torchqdynamics/mesolve/mesolve.py
@@ -40,9 +40,7 @@ def mesolve(
 
     # convert jump_ops to a tensor
     if len(jump_ops) == 0:
-        raise ValueError(
-            'Argument `jump_ops` must be a non-empty list of torch.Tensor.'
-        )
+        raise ValueError('Argument `jump_ops` must be a non-empty list of tensors.')
     jump_ops = to_tensor(jump_ops)
 
     # convert rho0 to a tensor and density matrix and batch by default

--- a/torchqdynamics/mesolve/mesolve.py
+++ b/torchqdynamics/mesolve/mesolve.py
@@ -19,7 +19,7 @@ def mesolve(
     *,
     exp_ops: Optional[List[OperatorLike]] = None,
     save_states: bool = True,
-    gradient_alg: Literal[None, 'autograd', 'adjoint'] = None,
+    gradient_alg: Optional[Literal['autograd', 'adjoint']] = None,
     parameters: Optional[Tuple[nn.Parameter, ...]] = None,
     solver: Optional[SolverOption] = None,
 ):

--- a/torchqdynamics/mesolve/mesolve.py
+++ b/torchqdynamics/mesolve/mesolve.py
@@ -5,14 +5,14 @@ import torch.nn as nn
 
 from ..odeint import odeint
 from ..solver_options import SolverOption
-from ..types import OperatorLike, TensorLike, TimeDependentOperatorLike, to_tensor
+from ..types import OperatorLike, TDOperatorLike, TensorLike, to_tensor
 from ..utils import is_ket, ket_to_dm
 from .rouchon import MERouchon1, MERouchon1_5, MERouchon2
 from .solver_options import Rouchon1, Rouchon1_5, Rouchon2
 
 
 def mesolve(
-    H: TimeDependentOperatorLike,
+    H: TDOperatorLike,
     jump_ops: List[OperatorLike],
     rho0: OperatorLike,
     t_save: TensorLike,

--- a/torchqdynamics/mesolve/rouchon.py
+++ b/torchqdynamics/mesolve/rouchon.py
@@ -1,6 +1,7 @@
 from math import sqrt
 
 import torch
+from torch import Tensor
 
 from ..odeint import AdjointQSolver
 from ..solver_options import SolverOption
@@ -11,8 +12,7 @@ from ..utils import trace
 
 class MERouchon(AdjointQSolver):
     def __init__(
-        self, H: TimeDependentOperator, jump_ops: torch.Tensor,
-        solver_options: SolverOption
+        self, H: TimeDependentOperator, jump_ops: Tensor, solver_options: SolverOption
     ):
         # Args:
         #     H: (b_H, n, n)
@@ -27,7 +27,7 @@ class MERouchon(AdjointQSolver):
 
 
 class MERouchon1(MERouchon):
-    def forward(self, t: float, dt: float, rho: torch.Tensor):
+    def forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1."""
         # Args:
         #     rho: (b_H, b_rho0, n, n)
@@ -50,12 +50,12 @@ class MERouchon1(MERouchon):
 
         return rho
 
-    def forward_adjoint(self, t: float, dt: float, phi: torch.Tensor):
+    def forward_adjoint(self, t: float, dt: float, phi: Tensor):
         raise NotImplementedError
 
 
 class MERouchon1_5(MERouchon):
-    def forward(self, t: float, dt: float, rho: torch.Tensor):
+    def forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1.5."""
         # Args:
         #     rho: (b_H, b_rho0, n, n)
@@ -84,12 +84,12 @@ class MERouchon1_5(MERouchon):
 
         return rho
 
-    def forward_adjoint(self, t: float, dt: float, phi: torch.Tensor):
+    def forward_adjoint(self, t: float, dt: float, phi: Tensor):
         raise NotImplementedError
 
 
 class MERouchon2(MERouchon):
-    def forward(self, t: float, dt: float, rho: torch.Tensor):
+    def forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 2.
 
         NOTE: For fast time-varying Hamiltonians, this method is not order 2 because the
@@ -120,5 +120,5 @@ class MERouchon2(MERouchon):
 
         return rho
 
-    def forward_adjoint(self, t: float, dt: float, phi: torch.Tensor):
+    def forward_adjoint(self, t: float, dt: float, phi: Tensor):
         raise NotImplementedError

--- a/torchqdynamics/mesolve/rouchon.py
+++ b/torchqdynamics/mesolve/rouchon.py
@@ -6,14 +6,12 @@ from torch import Tensor
 from ..odeint import AdjointQSolver
 from ..solver_options import SolverOption
 from ..solver_utils import inv_sqrtm, kraus_map
-from ..types import TimeDependentOperator
+from ..types import TDOperator
 from ..utils import trace
 
 
 class MERouchon(AdjointQSolver):
-    def __init__(
-        self, H: TimeDependentOperator, jump_ops: Tensor, solver_options: SolverOption
-    ):
+    def __init__(self, H: TDOperator, jump_ops: Tensor, solver_options: SolverOption):
         # Args:
         #     H: (b_H, n, n)
 

--- a/torchqdynamics/mesolve/rouchon.py
+++ b/torchqdynamics/mesolve/rouchon.py
@@ -28,10 +28,10 @@ class MERouchon1(MERouchon):
     def forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1."""
         # Args:
-        #     rho: (b_H, b_rho0, n, n)
+        #     rho: (b_H, b_rho, n, n)
         #
         # Returns:
-        #     (b_H, b_rho0, n, n)
+        #     (b_H, b_rho, n, n)
 
         # non-hermitian Hamiltonian at time t
         H_nh = self.H - 0.5j * self.sum_nojump  # (b_H, 1, n, n)
@@ -56,10 +56,10 @@ class MERouchon1_5(MERouchon):
     def forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 1.5."""
         # Args:
-        #     rho: (b_H, b_rho0, n, n)
+        #     rho: (b_H, b_rho, n, n)
         #
         # Returns:
-        #     (b_H, b_rho0, n, n)
+        #     (b_H, b_rho, n, n)
 
         # non-hermitian Hamiltonian at time t
         H_nh = self.H - 0.5j * self.sum_nojump  # (b_H, 1, n, n)
@@ -90,15 +90,17 @@ class MERouchon2(MERouchon):
     def forward(self, t: float, dt: float, rho: Tensor):
         """Compute rho(t+dt) using a Rouchon method of order 2.
 
-        NOTE: For fast time-varying Hamiltonians, this method is not order 2 because the
-        second-order time derivative term is neglected. This term could be added in the
-        zero-th order Kraus operator if needed, as M0 += -0.5j * dt**2 * \dot{H}.
+        Note:
+            For fast time-varying Hamiltonians, this method is not order 2 because the
+            second-order time derivative term is neglected. This term could be added in
+            the zero-th order Kraus operator if needed, as `M0 += -0.5j * dt**2 *
+            \dot{H}`.
         """
         # Args:
-        #     rho: (b_H, b_rho0, n, n)
+        #     rho: (b_H, b_rho, n, n)
         #
         # Returns:
-        #     (b_H, b_rho0, n, n)
+        #     (b_H, b_rho, n, n)
 
         # non-hermitian Hamiltonian at time t
         H_nh = self.H - 0.5j * self.sum_nojump  # (b_H, 1, n, n)

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Literal
+from typing import Literal, Optional
 
 import torch
 from torch import Tensor
@@ -32,7 +32,7 @@ def odeint(
     t_save: Tensor,
     exp_ops: Tensor,
     save_states: bool,
-    gradient_alg: Literal[None, 'autograd', 'adjoint'],
+    gradient_alg: Optional[Literal['autograd', 'adjoint']],
 ):
     # Args:
     #     y0: (..., m, n)

--- a/torchqdynamics/sesolve/euler.py
+++ b/torchqdynamics/sesolve/euler.py
@@ -2,11 +2,11 @@ from torch import Tensor
 
 from ..odeint import ForwardQSolver
 from ..solver_options import SolverOption
-from ..types import TimeDependentOperator
+from ..types import TDOperator
 
 
 class SEEuler(ForwardQSolver):
-    def __init__(self, H: TimeDependentOperator, solver_options: SolverOption):
+    def __init__(self, H: TDOperator, solver_options: SolverOption):
         # Args:
         #     H: (b_H, n, n)
 

--- a/torchqdynamics/sesolve/euler.py
+++ b/torchqdynamics/sesolve/euler.py
@@ -1,4 +1,4 @@
-import torch
+from torch import Tensor
 
 from ..odeint import ForwardQSolver
 from ..solver_options import SolverOption
@@ -15,7 +15,7 @@ class SEEuler(ForwardQSolver):
 
         self.options = solver_options
 
-    def forward(self, t: float, dt: float, psi: torch.Tensor):
+    def forward(self, t: float, dt: float, psi: Tensor):
         # Args:
         #     psi: (b_H, b_psi, n, 1)
         #

--- a/torchqdynamics/sesolve/sesolve.py
+++ b/torchqdynamics/sesolve/sesolve.py
@@ -2,6 +2,7 @@ from typing import List, Literal, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from torch import Tensor
 
 from ..odeint import odeint
 from ..solver_options import Euler, SolverOption
@@ -19,7 +20,7 @@ def sesolve(
     solver: Optional[SolverOption] = None,
     gradient_alg: Optional[Literal['autograd', 'adjoint']] = None,
     parameters: Optional[Tuple[nn.Parameter, ...]] = None,
-) -> torch.Tensor:
+) -> Tuple[Tensor, Tensor]:
     # Args:
     #     H: (b_H?, n, n)
     #     psi0: (b_psi0?, n, 1)

--- a/torchqdynamics/sesolve/sesolve.py
+++ b/torchqdynamics/sesolve/sesolve.py
@@ -6,12 +6,12 @@ from torch import Tensor
 
 from ..odeint import odeint
 from ..solver_options import Euler, SolverOption
-from ..types import OperatorLike, TensorLike, TimeDependentOperatorLike, to_tensor
+from ..types import OperatorLike, TDOperatorLike, TensorLike, to_tensor
 from .euler import SEEuler
 
 
 def sesolve(
-    H: TimeDependentOperatorLike,
+    H: TDOperatorLike,
     psi0: OperatorLike,
     t_save: TensorLike,
     *,

--- a/torchqdynamics/smesolve.py
+++ b/torchqdynamics/smesolve.py
@@ -1,20 +1,20 @@
 from typing import Any, Dict, List, Optional
 
 import numpy as np
-import torch
+from torch import Tensor
 
 
 def smesolve(
-    H: torch.Tensor,
-    Ls: List[torch.Tensor],
-    Ms: List[torch.Tensor],
+    H: Tensor,
+    Ls: List[Tensor],
+    Ms: List[Tensor],
     etas: List[float],
-    rho0: torch.Tensor,
+    rho0: Tensor,
     tlist: np.ndarray,
     ntrajs: int,
     solver: str,
     options: Optional[Dict[str, Any]] = None,
-) -> torch.Tensor:
+) -> Tensor:
     raise NotImplementedError(
         'the Stochastic Master Equation solvers are not implemented yet, come '
         'back soon!'

--- a/torchqdynamics/solver_utils.py
+++ b/torchqdynamics/solver_utils.py
@@ -1,7 +1,8 @@
 import torch
+from torch import Tensor
 
 
-def kraus_map(rho: torch.Tensor, O: torch.Tensor) -> torch.Tensor:
+def kraus_map(rho: Tensor, O: Tensor) -> Tensor:
     """Compute the application of a Kraus map on an input density matrix.
 
     This is equivalent to `torch.sum(operators @ rho[None,...] @ operators.adjoint(),
@@ -18,7 +19,7 @@ def kraus_map(rho: torch.Tensor, O: torch.Tensor) -> torch.Tensor:
     return torch.einsum('abij,a...jk,abkl->a...il', O, rho, O.adjoint())
 
 
-def inv_sqrtm(mat: torch.Tensor) -> torch.Tensor:
+def inv_sqrtm(mat: Tensor) -> Tensor:
     """Compute the inverse square root of a matrix using its eigendecomposition.
 
     TODO: Replace with Schur decomposition once released by PyTorch.
@@ -31,7 +32,7 @@ def inv_sqrtm(mat: torch.Tensor) -> torch.Tensor:
     return vecs @ torch.linalg.solve(vecs, torch.diag(vals**(-0.5)), left=False)
 
 
-def bexpect(operators: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
+def bexpect(operators: Tensor, state: Tensor) -> Tensor:
     """Compute the expectation values of many operators on a quantum state or
     density matrix. The method is batchable over the operators and the state.
 

--- a/torchqdynamics/types.py
+++ b/torchqdynamics/types.py
@@ -3,14 +3,15 @@ from typing import Callable, List, Optional, Union, get_args
 import numpy as np
 import torch
 from qutip import Qobj
+from torch import Tensor
 
 from .utils import from_qutip
 
 # TODO: add typing for Hamiltonian with piecewise-constant factor
-TimeDependentOperator = Union[torch.Tensor, Callable[[float], torch.Tensor]]
+TimeDependentOperator = Union[Tensor, Callable[[float], Tensor]]
 
 # type for objects convertible to a torch tensor using `torch.as_tensor`
-TensorLike = Union[List, np.ndarray, torch.Tensor]
+TensorLike = Union[List, np.ndarray, Tensor]
 
 # type for objects convertible to a torch tensor using `to_tensor`
 OperatorLike = Union[TensorLike, Qobj]
@@ -19,7 +20,7 @@ OperatorLike = Union[TensorLike, Qobj]
 TimeDependentOperatorLike = Union[OperatorLike, Callable[[float], OperatorLike]]
 
 
-def to_tensor(x: Optional[Union[OperatorLike, List[OperatorLike]]]) -> torch.Tensor:
+def to_tensor(x: Optional[Union[OperatorLike, List[OperatorLike]]]) -> Tensor:
     """Convert a `OperatorLike` object or a list of `OperatorLike` object to a PyTorch
     tensor.
 

--- a/torchqdynamics/types.py
+++ b/torchqdynamics/types.py
@@ -8,7 +8,7 @@ from torch import Tensor
 from .utils import from_qutip
 
 # TODO: add typing for Hamiltonian with piecewise-constant factor
-TimeDependentOperator = Union[Tensor, Callable[[float], Tensor]]
+TDOperator = Union[Tensor, Callable[[float], Tensor]]
 
 # type for objects convertible to a torch tensor using `torch.as_tensor`
 TensorLike = Union[List, np.ndarray, Tensor]
@@ -16,8 +16,8 @@ TensorLike = Union[List, np.ndarray, Tensor]
 # type for objects convertible to a torch tensor using `to_tensor`
 OperatorLike = Union[TensorLike, Qobj]
 
-# type for objects convertible to a `TimeDependentOperator` using `time_dependent_to_tensor`
-TimeDependentOperatorLike = Union[OperatorLike, Callable[[float], OperatorLike]]
+# type for objects convertible to a `TDOperator` using `time_dependent_to_tensor`
+TDOperatorLike = Union[OperatorLike, Callable[[float], OperatorLike]]
 
 
 def to_tensor(x: Optional[Union[OperatorLike, List[OperatorLike]]]) -> Tensor:

--- a/torchqdynamics/utils.py
+++ b/torchqdynamics/utils.py
@@ -2,13 +2,14 @@ from typing import List, Optional
 
 import torch
 from qutip import Qobj
+from torch import Tensor
 
 
-def is_ket(x: torch.Tensor) -> torch.Tensor:
+def is_ket(x: Tensor) -> Tensor:
     return x.size(-1) == 1
 
 
-def ket_to_bra(x: torch.Tensor) -> torch.Tensor:
+def ket_to_bra(x: Tensor) -> Tensor:
     """Linear map (bra) representation of a state vector (ket).
 
     Args:
@@ -20,7 +21,7 @@ def ket_to_bra(x: torch.Tensor) -> torch.Tensor:
     return x.adjoint()
 
 
-def ket_to_dm(x: torch.Tensor) -> torch.Tensor:
+def ket_to_dm(x: Tensor) -> Tensor:
     """Density matrix formed by the outer product of a state vector (ket).
 
     Args:
@@ -32,7 +33,7 @@ def ket_to_dm(x: torch.Tensor) -> torch.Tensor:
     return x @ ket_to_bra(x)
 
 
-def ket_overlap(x: torch.Tensor, y: torch.Tensor) -> torch.complex:
+def ket_overlap(x: Tensor, y: Tensor) -> torch.complex:
     """Return the overlap (inner product) between two state vectors (kets).
 
     Args:
@@ -45,7 +46,7 @@ def ket_overlap(x: torch.Tensor, y: torch.Tensor) -> torch.complex:
     return (ket_to_bra(x) @ y).squeeze(-1).sum(-1)
 
 
-def ket_fidelity(x: torch.Tensor, y: torch.Tensor) -> float:
+def ket_fidelity(x: Tensor, y: Tensor) -> float:
     """Return the fidelity between two state vectors (kets).
 
     The fidelity between two pure states $\varphi$, $\psi$ is defined by their
@@ -68,7 +69,7 @@ def ket_fidelity(x: torch.Tensor, y: torch.Tensor) -> float:
     return ket_overlap(x, y).abs().pow(2)
 
 
-def dissipator(L: torch.Tensor, rho: torch.Tensor) -> torch.Tensor:
+def dissipator(L: Tensor, rho: Tensor) -> Tensor:
     """Apply the dissipation superoperator to a density matrix.
 
     The dissipation superoperator $\mathcal{D}[L](\cdot)$ is defined by
@@ -90,11 +91,7 @@ def dissipator(L: torch.Tensor, rho: torch.Tensor) -> torch.Tensor:
     )
 
 
-def lindbladian(
-    H: torch.Tensor,
-    Ls: torch.Tensor,
-    rho: torch.Tensor,
-) -> torch.Tensor:
+def lindbladian(H: Tensor, Ls: Tensor, rho: Tensor) -> Tensor:
     """Apply the Lindbladian superoperator to a density matrix.
 
     The system Lindbladian $\mathcal{L}(\cdot)$ is the superoperator
@@ -115,12 +112,12 @@ def lindbladian(
     return -1j * (H @ rho - rho @ H) + dissipator(Ls, rho).sum(0)
 
 
-def trace(rho: torch.Tensor) -> torch.Tensor:
+def trace(rho: Tensor) -> Tensor:
     """Compute the batched trace of a tensor over its last two dimensions."""
     return torch.einsum('...ii', rho)
 
 
-def expect(operator: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
+def expect(operator: Tensor, state: Tensor) -> Tensor:
     """Compute the expectation value of an operator on a quantum state or density
     matrix. The method is batchable over the state, but not over the operator.
 
@@ -135,7 +132,7 @@ def expect(operator: torch.Tensor, state: torch.Tensor) -> torch.Tensor:
     return torch.einsum('ij,...ji', operator, state)
 
 
-def from_qutip(x: Qobj) -> torch.Tensor:
+def from_qutip(x: Qobj) -> Tensor:
     """Convert a QuTiP quantum object to a PyTorch tensor.
 
     Args:
@@ -147,7 +144,7 @@ def from_qutip(x: Qobj) -> torch.Tensor:
     return torch.from_numpy(x.full())
 
 
-def to_qutip(x: torch.Tensor, dims: Optional[List] = None) -> Qobj:
+def to_qutip(x: Tensor, dims: Optional[List] = None) -> Qobj:
     """Convert a PyTorch tensor to a QuTiP quantum object.
 
     Args:


### PR DESCRIPTION
Git had a hard time figuring out how to merge #37 due to the many renamings and moving around. This PR replace #37 and re-implements all the changes cleanly on the new `main`. @gautierronan I made you the author of all the commits (and bc I pushed them I'm "co-author"), so I'll let you merge if you're satisfied 😉 