### PR TITLE
Proposal for a testing framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,9 @@ black     auto-format the code (black)
 codespell check for misspellings (codespell)
 flake8    check code style (flake8)
 lint      lint the code and check style (isort + black + codespell + flake8)
-test      run the unit tests suite (pytest)
+test      run the unit tests suite excluding long tests (pytest)
+test-long run the unit tests suite including only long tests (pytest)
+test-all  run the complete unit tests suite (pytest)
 all       run all tasks before a commit (isort + black + codespell + flake8 + pytest)
 ci        run all the CI checks
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ ci = { cmd = """echo '\n>>> isort' && isort --check . &&
                 echo '\n>>> black' && black --check . &&
                 task codespell &&
                 task flake8 &&
-                task test-all""", help = "run all the CI checks" }
+                task test""", help = "run all the CI checks" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,12 @@ black = { cmd = "echo '\n>>> black' && black .", help = "auto-format the code (b
 codespell = { cmd = "echo '\n>>> codespell' && codespell tests torchqdynamics", help = "check for misspellings (codespell)" }
 flake8 = { cmd = "echo '\n>>> flake8' && flake8 tests torchqdynamics", help = "check code style (flake8)" }
 lint = { cmd = "task isort && task black && task codespell && task flake8", help = "lint the code and check style (isort + black + codespell + flake8)" }
-test = { cmd = "echo '\n>>> pytest' && pytest", help = "run the unit tests suite (pytest)" }
+test = { cmd = "echo '\n>>> pytest -v -m \"not long\"' && pytest -v -m \"not long\"", help = "run the unit tests suite excluding long tests (pytest)" }
+test-long = { cmd = "echo '\n>>> pytest -v -m \"long\"' && pytest -v -m \"long\"", help = "run the unit tests suite including only long tests (pytest)" }
+test-all = { cmd = "echo '\n>>> pytest' && pytest", help = "run the complete unit tests suite (pytest)" }
 all = { cmd = "task lint && task test", help = "run all tasks before a commit (isort + black + codespell + flake8 + pytest)" }
 ci = { cmd = """echo '\n>>> isort' && isort --check . &&
                 echo '\n>>> black' && black --check . &&
                 task codespell &&
                 task flake8 &&
-                task test""", help = "run all the CI checks" }
+                task test-all""", help = "run all the CI checks" }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    long: mark a test as having a long runtime.

--- a/tests/mesolve/mesolver_test.py
+++ b/tests/mesolve/mesolver_test.py
@@ -54,8 +54,7 @@ class MESolverTest:
         system: OpenSystem,
         *,
         num_t_save: int,
-        rtol: float = 1e-05,
-        atol: float = 1e-08,
+        norm_atol: float = 1e-2,
     ):
         t_save = system.t_save(num_t_save)
 
@@ -68,7 +67,7 @@ class MESolverTest:
             solver=solver,
         )
 
-        assert torch.allclose(rho_save, system.rhos(t_save), rtol=rtol, atol=atol)
+        assert torch.norm(rho_save - system.rhos(t_save)) <= norm_atol
 
     def test_rho_save(self):
         pass

--- a/tests/mesolve/mesolver_test.py
+++ b/tests/mesolve/mesolver_test.py
@@ -1,0 +1,74 @@
+import torch
+
+import torchqdynamics as tq
+from torchqdynamics.solver_options import SolverOption
+
+from .open_system import OpenSystem
+
+
+class MESolverTest:
+    def _test_batching(self, solver: SolverOption, system: OpenSystem):
+        """Test the batching of `H` and `rho0` in `mesolve`, and the returned object
+        sizes."""
+        n = system.n
+        n_exp_ops = len(system.exp_ops)
+        b_H = len(system.H_batched)
+        b_rho0 = len(system.rho0_batched)
+        nt = 11
+
+        run_mesolve = lambda H, rho0: tq.mesolve(
+            H,
+            system.jump_ops,
+            rho0,
+            system.t_save(nt),
+            exp_ops=system.exp_ops,
+            solver=solver,
+        )
+
+        # no batching
+        rho_save, exp_save = run_mesolve(system.H, system.rho0)
+        assert rho_save.shape == (nt, n, n)
+        assert exp_save.shape == (n_exp_ops, nt)
+
+        # batched H
+        rho_save, exp_save = run_mesolve(system.H_batched, system.rho0)
+        assert rho_save.shape == (b_H, nt, n, n)
+        assert exp_save.shape == (b_H, n_exp_ops, nt)
+
+        # batched rho0
+        rho_save, exp_save = run_mesolve(system.H, system.rho0_batched)
+        assert rho_save.shape == (b_rho0, nt, n, n)
+        assert exp_save.shape == (b_rho0, n_exp_ops, nt)
+
+        # batched H and rho0
+        rho_save, exp_save = run_mesolve(system.H_batched, system.rho0_batched)
+        assert rho_save.shape == (b_H, b_rho0, nt, n, n)
+        assert exp_save.shape == (b_H, b_rho0, n_exp_ops, nt)
+
+    def test_batching(self):
+        pass
+
+    def _test_rho_save(
+        self,
+        solver: SolverOption,
+        system: OpenSystem,
+        *,
+        nt: int,
+        rtol: float = 1e-05,
+        atol: float = 1e-08,
+    ):
+        t_save = system.t_save(nt)
+
+        rho_save, _ = tq.mesolve(
+            system.H,
+            system.jump_ops,
+            system.rho0,
+            t_save,
+            exp_ops=system.exp_ops,
+            solver=solver,
+        )
+
+        assert torch.allclose(rho_save, system.rhos(t_save), rtol=rtol, atol=atol)
+
+    def test_rho_save(self):
+        pass

--- a/tests/mesolve/mesolver_test.py
+++ b/tests/mesolve/mesolver_test.py
@@ -14,36 +14,36 @@ class MESolverTest:
         n_exp_ops = len(system.exp_ops)
         b_H = len(system.H_batched)
         b_rho0 = len(system.rho0_batched)
-        nt = 11
+        num_t_save = 11
 
         run_mesolve = lambda H, rho0: tq.mesolve(
             H,
             system.jump_ops,
             rho0,
-            system.t_save(nt),
+            system.t_save(num_t_save),
             exp_ops=system.exp_ops,
             solver=solver,
         )
 
         # no batching
         rho_save, exp_save = run_mesolve(system.H, system.rho0)
-        assert rho_save.shape == (nt, n, n)
-        assert exp_save.shape == (n_exp_ops, nt)
+        assert rho_save.shape == (num_t_save, n, n)
+        assert exp_save.shape == (n_exp_ops, num_t_save)
 
         # batched H
         rho_save, exp_save = run_mesolve(system.H_batched, system.rho0)
-        assert rho_save.shape == (b_H, nt, n, n)
-        assert exp_save.shape == (b_H, n_exp_ops, nt)
+        assert rho_save.shape == (b_H, num_t_save, n, n)
+        assert exp_save.shape == (b_H, n_exp_ops, num_t_save)
 
         # batched rho0
         rho_save, exp_save = run_mesolve(system.H, system.rho0_batched)
-        assert rho_save.shape == (b_rho0, nt, n, n)
-        assert exp_save.shape == (b_rho0, n_exp_ops, nt)
+        assert rho_save.shape == (b_rho0, num_t_save, n, n)
+        assert exp_save.shape == (b_rho0, n_exp_ops, num_t_save)
 
         # batched H and rho0
         rho_save, exp_save = run_mesolve(system.H_batched, system.rho0_batched)
-        assert rho_save.shape == (b_H, b_rho0, nt, n, n)
-        assert exp_save.shape == (b_H, b_rho0, n_exp_ops, nt)
+        assert rho_save.shape == (b_H, b_rho0, num_t_save, n, n)
+        assert exp_save.shape == (b_H, b_rho0, n_exp_ops, num_t_save)
 
     def test_batching(self):
         pass
@@ -53,11 +53,11 @@ class MESolverTest:
         solver: SolverOption,
         system: OpenSystem,
         *,
-        nt: int,
+        num_t_save: int,
         rtol: float = 1e-05,
         atol: float = 1e-08,
     ):
-        t_save = system.t_save(nt)
+        t_save = system.t_save(num_t_save)
 
         rho_save, _ = tq.mesolve(
             system.H,

--- a/tests/mesolve/mesolver_test.py
+++ b/tests/mesolve/mesolver_test.py
@@ -67,7 +67,8 @@ class MESolverTest:
             solver=solver,
         )
 
-        assert torch.norm(rho_save - system.rhos(t_save)) <= norm_atol
+        errs = torch.norm(rho_save - system.rhos(t_save), dim=(-2, -1))
+        assert torch.all(errs <= norm_atol)
 
     def test_rho_save(self):
         pass

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -64,6 +64,3 @@ class LeakyCavity(OpenSystem):
         )
         rho_t = qt.coherent(self.n, alpha_t)
         return tq.ket_to_dm(tq.from_qutip(rho_t))
-
-
-leaky_cavity_8 = LeakyCavity(n=8, kappa=1.0, delta=2 * np.pi, alpha0=1.0)

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -63,7 +63,7 @@ class LeakyCavity(OpenSystem):
             self.alpha0 * np.exp(-1j * self.delta * t) * np.exp(-self.kappa / 2 * t)
         )
         rho_t = qt.coherent(self.n, alpha_t)
-        return tq.from_qutip(rho_t)
+        return tq.ket_to_dm(tq.from_qutip(rho_t))
 
 
 leaky_cavity_8 = LeakyCavity(n=8, kappa=1.0, delta=2 * np.pi, alpha0=1.0)

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -1,0 +1,69 @@
+from abc import ABC, abstractmethod
+
+import numpy as np
+import qutip as qt
+import torch
+from torch import Tensor
+
+import torchqdynamics as tq
+
+
+class OpenSystem(ABC):
+    def __init__(self):
+        self.n = None
+        self.H = None
+        self.H_batched = None
+        self.jump_ops = None
+        self.rho0 = None
+        self.rho0_batched = None
+        self.exp_ops = None
+
+    @abstractmethod
+    def t_save(self, n: int) -> Tensor:
+        pass
+
+    def rho(self, t: float) -> Tensor:
+        raise NotImplementedError
+
+    def rhos(self, t: Tensor) -> Tensor:
+        return torch.stack([self.rho(t_.item()) for t_ in t])
+
+
+class LeakyCavity(OpenSystem):
+    # `H_batched: (3, n, n)
+    # `jump_ops`: (2, n, n)
+    # `rho0_batched`: (4, n, n)
+    # `exp_ops`: (2, n, n)
+
+    def __init__(self, *, n: int, kappa: float, delta: float, alpha0: complex):
+        self.n, self.kappa, self.delta, self.alpha0 = n, kappa, delta, alpha0
+
+        a = qt.destroy(n)
+        adag = a.dag()
+
+        self.H = delta * adag * a
+        self.H_batched = [0.5 * self.H, self.H, 2 * self.H]
+        self.jump_ops = [np.sqrt(kappa) * a, np.eye(n)]
+        self.exp_ops = [(a + adag) / np.sqrt(2), (a - adag) / (np.sqrt(2) * 1j)]
+
+        self.rho0 = qt.coherent(n, alpha0)
+        self.rho0_batched = [
+            qt.coherent(n, alpha0),
+            qt.coherent(n, 1j * alpha0),
+            qt.coherent(n, -alpha0),
+            qt.coherent(n, -1j * alpha0),
+        ]
+
+    def t_save(self, n: int) -> Tensor:
+        t_end = self.delta / (2 * np.pi)  # a full rotation
+        return torch.linspace(0.0, t_end, n)
+
+    def rho(self, t: float) -> Tensor:
+        alpha_t = (
+            self.alpha0 * np.exp(-1j * self.delta * t) * np.exp(-self.kappa / 2 * t)
+        )
+        rho_t = qt.coherent(self.n, alpha_t)
+        return tq.from_qutip(rho_t)
+
+
+leaky_cavity_8 = LeakyCavity(n=8, kappa=1.0, delta=2 * np.pi, alpha0=1.0)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -1,9 +1,12 @@
+import numpy as np
 import pytest
 
 import torchqdynamics as tq
 
 from .mesolver_test import MESolverTest
-from .open_system import leaky_cavity_8
+from .open_system import LeakyCavity
+
+leaky_cavity_8 = LeakyCavity(n=8, kappa=1.0, delta=2 * np.pi, alpha0=1.0)
 
 
 class TestMEEuler(MESolverTest):

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -15,4 +15,4 @@ class TestMEEuler(MESolverTest):
 
     def test_rho_save(self):
         solver = tq.solver.Euler(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11, norm_atol=1e-2)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -11,8 +11,7 @@ class TestMEEuler(MESolverTest):
         solver = tq.solver.Euler(dt=1e-2)
         self._test_batching(solver, leaky_cavity_8)
 
-    @pytest.mark.skip(reason='failing - to fix')
     @pytest.mark.long
     def test_rho_save(self):
-        solver = tq.solver.Euler(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e-3, atol=1e-3)
+        solver = tq.solver.Euler(dt=1e-5)
+        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e0)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -14,4 +14,4 @@ class TestMEEuler(MESolverTest):
     @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Euler(dt=1e-5)
-        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e0)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=51, rtol=1e0)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -1,32 +1,18 @@
-import numpy as np
-import qutip as qt
+import pytest
 
 import torchqdynamics as tq
 
+from .mesolver_test import MESolverTest
+from .open_system import leaky_cavity_8
 
-def test_mesolve_euler_cheap():
-    """Cheap test of the Euler method of mesolve."""
-    # parameters
-    n = 8
-    kappa = 1.0
-    delta = 2 * np.pi
-    alpha0 = 1.0
 
-    # operators
-    a = qt.destroy(n)
-    adag = a.dag()
-    H = delta * adag * a
-    jump_ops = [np.sqrt(kappa) * a, np.eye(n)]
-    exp_ops = [(a + adag) / np.sqrt(2), (a - adag) / (np.sqrt(2) * 1j)]
-    num_exp_ops = len(exp_ops)
+class TestMEEuler(MESolverTest):
+    def test_batching(self):
+        solver = tq.solver.Euler(dt=1e-2)
+        self._test_batching(solver, leaky_cavity_8)
 
-    # other arguments
-    rho0 = qt.coherent(n, alpha0)
-    num_t_save = 51
-    t_save = np.linspace(0.0, delta / (2 * np.pi), num_t_save)  # a full tour
-    solver = tq.solver.Euler(dt=1e-3)
-
-    # run solver
-    states, exp = tq.mesolve(H, jump_ops, rho0, t_save, exp_ops=exp_ops, solver=solver)
-    assert states.shape == (num_t_save, n, n)
-    assert exp.shape == (num_exp_ops, num_t_save)
+    @pytest.mark.skip(reason='failing - to fix')
+    @pytest.mark.long
+    def test_rho_save(self):
+        solver = tq.solver.Euler(dt=1e-4)
+        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e-3, atol=1e-3)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import torchqdynamics as tq
 
@@ -14,7 +13,6 @@ class TestMEEuler(MESolverTest):
         solver = tq.solver.Euler(dt=1e-2)
         self._test_batching(solver, leaky_cavity_8)
 
-    @pytest.mark.long
     def test_rho_save(self):
-        solver = tq.solver.Euler(dt=1e-5)
-        self._test_rho_save(solver, leaky_cavity_8, num_t_save=51, rtol=1e0)
+        solver = tq.solver.Euler(dt=1e-4)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11, norm_atol=1e-2)

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -1,9 +1,12 @@
+import numpy as np
 import pytest
 
 import torchqdynamics as tq
 
 from .mesolver_test import MESolverTest
-from .open_system import leaky_cavity_8
+from .open_system import LeakyCavity
+
+leaky_cavity_8 = LeakyCavity(n=8, kappa=1.0, delta=2 * np.pi, alpha0=1.0)
 
 
 class TestMERouchon1(MESolverTest):

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -11,11 +11,10 @@ class TestMERouchon1(MESolverTest):
         solver = tq.solver.Rouchon1(dt=1e-2)
         self._test_batching(solver, leaky_cavity_8)
 
-    @pytest.mark.skip(reason='failing - to fix')
     @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon1(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e-3, atol=1e-3)
+        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e0)
 
 
 class TestMERouchon1_5(MESolverTest):
@@ -29,7 +28,7 @@ class TestMERouchon1_5(MESolverTest):
     @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon1_5(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e-3, atol=1e-3)
+        self._test_rho_save(solver, leaky_cavity_8, nt=51)
 
 
 class TestMERouchon2(MESolverTest):
@@ -37,8 +36,7 @@ class TestMERouchon2(MESolverTest):
         solver = tq.solver.Rouchon2(dt=1e-2)
         self._test_batching(solver, leaky_cavity_8)
 
-    @pytest.mark.skip(reason='failing - to fix')
     @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon2(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e-3, atol=1e-3)
+        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e0)

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -1,0 +1,44 @@
+import pytest
+
+import torchqdynamics as tq
+
+from .mesolver_test import MESolverTest
+from .open_system import leaky_cavity_8
+
+
+class TestMERouchon1(MESolverTest):
+    def test_batching(self):
+        solver = tq.solver.Rouchon1(dt=1e-2)
+        self._test_batching(solver, leaky_cavity_8)
+
+    @pytest.mark.skip(reason='failing - to fix')
+    @pytest.mark.long
+    def test_rho_save(self):
+        solver = tq.solver.Rouchon1(dt=1e-4)
+        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e-3, atol=1e-3)
+
+
+class TestMERouchon1_5(MESolverTest):
+    @pytest.mark.skip(reason='failing - to fix')
+    @pytest.mark.long
+    def test_batching(self):
+        solver = tq.solver.Rouchon1_5(dt=1e-2)
+        self._test_batching(solver, leaky_cavity_8)
+
+    @pytest.mark.skip(reason='failing - to fix')
+    @pytest.mark.long
+    def test_rho_save(self):
+        solver = tq.solver.Rouchon1_5(dt=1e-4)
+        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e-3, atol=1e-3)
+
+
+class TestMERouchon2(MESolverTest):
+    def test_batching(self):
+        solver = tq.solver.Rouchon2(dt=1e-2)
+        self._test_batching(solver, leaky_cavity_8)
+
+    @pytest.mark.skip(reason='failing - to fix')
+    @pytest.mark.long
+    def test_rho_save(self):
+        solver = tq.solver.Rouchon2(dt=1e-4)
+        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e-3, atol=1e-3)

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -16,7 +16,7 @@ class TestMERouchon1(MESolverTest):
 
     def test_rho_save(self):
         solver = tq.solver.Rouchon1(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11, norm_atol=1e-1)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11)
 
 
 class TestMERouchon1_5(MESolverTest):
@@ -28,7 +28,7 @@ class TestMERouchon1_5(MESolverTest):
     @pytest.mark.skip(reason='failing - to fix')
     def test_rho_save(self):
         solver = tq.solver.Rouchon1_5(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11, norm_atol=1e-2)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11)
 
 
 class TestMERouchon2(MESolverTest):
@@ -37,5 +37,5 @@ class TestMERouchon2(MESolverTest):
         self._test_batching(solver, leaky_cavity_8)
 
     def test_rho_save(self):
-        solver = tq.solver.Rouchon2(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11, norm_atol=1e-2)
+        solver = tq.solver.Rouchon2(dt=1e-3)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11)

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -14,7 +14,7 @@ class TestMERouchon1(MESolverTest):
     @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon1(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e0)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=51, rtol=1e0)
 
 
 class TestMERouchon1_5(MESolverTest):
@@ -28,7 +28,7 @@ class TestMERouchon1_5(MESolverTest):
     @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon1_5(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, nt=51)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=51)
 
 
 class TestMERouchon2(MESolverTest):
@@ -39,4 +39,4 @@ class TestMERouchon2(MESolverTest):
     @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon2(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, nt=51, rtol=1e0)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=51, rtol=1e0)

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -14,24 +14,21 @@ class TestMERouchon1(MESolverTest):
         solver = tq.solver.Rouchon1(dt=1e-2)
         self._test_batching(solver, leaky_cavity_8)
 
-    @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon1(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, num_t_save=51, rtol=1e0)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11, norm_atol=1e-1)
 
 
 class TestMERouchon1_5(MESolverTest):
     @pytest.mark.skip(reason='failing - to fix')
-    @pytest.mark.long
     def test_batching(self):
         solver = tq.solver.Rouchon1_5(dt=1e-2)
         self._test_batching(solver, leaky_cavity_8)
 
     @pytest.mark.skip(reason='failing - to fix')
-    @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon1_5(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, num_t_save=51)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11, norm_atol=1e-2)
 
 
 class TestMERouchon2(MESolverTest):
@@ -39,7 +36,6 @@ class TestMERouchon2(MESolverTest):
         solver = tq.solver.Rouchon2(dt=1e-2)
         self._test_batching(solver, leaky_cavity_8)
 
-    @pytest.mark.long
     def test_rho_save(self):
         solver = tq.solver.Rouchon2(dt=1e-4)
-        self._test_rho_save(solver, leaky_cavity_8, num_t_save=51, rtol=1e0)
+        self._test_rho_save(solver, leaky_cavity_8, num_t_save=11, norm_atol=1e-2)

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -61,6 +61,3 @@ class Cavity(ClosedSystem):
         alpha_t = self.alpha0 * np.exp(-1j * self.delta * t)
         psi_t = qt.coherent(self.n, alpha_t)
         return tq.from_qutip(psi_t)
-
-
-cavity_8 = Cavity(n=8, delta=2 * np.pi, alpha0=1.0)

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -1,0 +1,64 @@
+from abc import ABC, abstractmethod
+
+import numpy as np
+import qutip as qt
+import torch
+from torch import Tensor
+
+import torchqdynamics as tq
+
+
+class ClosedSystem(ABC):
+    def __init__(self):
+        self.n = None
+        self.H = None
+        self.H_batched = None
+        self.psi0 = None
+        self.psi0_batched = None
+        self.exp_ops = None
+
+    @abstractmethod
+    def t_save(self, n: int) -> Tensor:
+        pass
+
+    def psi(self, t: float) -> Tensor:
+        raise NotImplementedError
+
+    def psis(self, t: Tensor) -> Tensor:
+        return torch.stack([self.psi(t_.item()) for t_ in t])
+
+
+class Cavity(ClosedSystem):
+    # `H_batched: (3, n, n)
+    # `psi0_batched`: (4, n, n)
+    # `exp_ops`: (2, n, n)
+
+    def __init__(self, *, n: int, delta: float, alpha0: complex):
+        self.n, self.delta, self.alpha0 = n, delta, alpha0
+
+        a = qt.destroy(n)
+        adag = a.dag()
+
+        self.H = delta * adag * a
+        self.H_batched = [0.5 * self.H, self.H, 2 * self.H]
+        self.exp_ops = [(a + adag) / np.sqrt(2), (a - adag) / (np.sqrt(2) * 1j)]
+
+        self.psi0 = qt.coherent(n, alpha0)
+        self.psi0_batched = [
+            qt.coherent(n, alpha0),
+            qt.coherent(n, 1j * alpha0),
+            qt.coherent(n, -alpha0),
+            qt.coherent(n, -1j * alpha0),
+        ]
+
+    def t_save(self, n: int) -> Tensor:
+        t_end = self.delta / (2 * np.pi)  # a full rotation
+        return torch.linspace(0.0, t_end, n)
+
+    def psi(self, t: float) -> Tensor:
+        alpha_t = self.alpha0 * np.exp(-1j * self.delta * t)
+        psi_t = qt.coherent(self.n, alpha_t)
+        return tq.from_qutip(psi_t)
+
+
+cavity_8 = Cavity(n=8, delta=2 * np.pi, alpha0=1.0)

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -34,7 +34,9 @@ class Cavity(ClosedSystem):
     # `exp_ops`: (2, n, n)
 
     def __init__(self, *, n: int, delta: float, alpha0: complex):
-        self.n, self.delta, self.alpha0 = n, delta, alpha0
+        self.n = n
+        self.delta = delta
+        self.alpha0 = alpha0
 
         a = qt.destroy(n)
         adag = a.dag()

--- a/tests/sesolve/sesolver_test.py
+++ b/tests/sesolve/sesolver_test.py
@@ -53,7 +53,7 @@ class SESolverTest:
         system: ClosedSystem,
         *,
         num_t_save: int,
-        norm_atol: float = 1e-3,
+        norm_atol: float = 1e-2,
     ):
         t_save = system.t_save(num_t_save)
 
@@ -65,7 +65,8 @@ class SESolverTest:
             solver=solver,
         )
 
-        assert torch.norm(psi_save - system.psis(t_save)) <= norm_atol
+        errs = torch.norm(psi_save - system.psis(t_save), dim=(-2, -1))
+        assert torch.all(errs <= norm_atol)
 
     def test_psi_save(self):
         pass

--- a/tests/sesolve/sesolver_test.py
+++ b/tests/sesolve/sesolver_test.py
@@ -16,7 +16,7 @@ class SESolverTest:
         b_psi0 = len(system.psi0_batched)
         nt = 11
 
-        run_mesolve = lambda H, psi0: tq.sesolve(
+        run_sesolve = lambda H, psi0: tq.sesolve(
             H,
             psi0,
             system.t_save(nt),
@@ -25,22 +25,22 @@ class SESolverTest:
         )
 
         # no batching
-        psi_save, exp_save = run_mesolve(system.H, system.psi0)
+        psi_save, exp_save = run_sesolve(system.H, system.psi0)
         assert psi_save.shape == (nt, n, 1)
         assert exp_save.shape == (n_exp_ops, nt)
 
         # batched H
-        psi_save, exp_save = run_mesolve(system.H_batched, system.psi0)
+        psi_save, exp_save = run_sesolve(system.H_batched, system.psi0)
         assert psi_save.shape == (b_H, nt, n, 1)
         assert exp_save.shape == (b_H, n_exp_ops, nt)
 
         # batched psi0
-        psi_save, exp_save = run_mesolve(system.H, system.psi0_batched)
+        psi_save, exp_save = run_sesolve(system.H, system.psi0_batched)
         assert psi_save.shape == (b_psi0, nt, n, 1)
         assert exp_save.shape == (b_psi0, n_exp_ops, nt)
 
         # batched H and psi0
-        psi_save, exp_save = run_mesolve(system.H_batched, system.psi0_batched)
+        psi_save, exp_save = run_sesolve(system.H_batched, system.psi0_batched)
         assert psi_save.shape == (b_H, b_psi0, nt, n, 1)
         assert exp_save.shape == (b_H, b_psi0, n_exp_ops, nt)
 

--- a/tests/sesolve/sesolver_test.py
+++ b/tests/sesolve/sesolver_test.py
@@ -14,35 +14,35 @@ class SESolverTest:
         n_exp_ops = len(system.exp_ops)
         b_H = len(system.H_batched)
         b_psi0 = len(system.psi0_batched)
-        nt = 11
+        num_t_save = 11
 
         run_sesolve = lambda H, psi0: tq.sesolve(
             H,
             psi0,
-            system.t_save(nt),
+            system.t_save(num_t_save),
             exp_ops=system.exp_ops,
             solver=solver,
         )
 
         # no batching
         psi_save, exp_save = run_sesolve(system.H, system.psi0)
-        assert psi_save.shape == (nt, n, 1)
-        assert exp_save.shape == (n_exp_ops, nt)
+        assert psi_save.shape == (num_t_save, n, 1)
+        assert exp_save.shape == (n_exp_ops, num_t_save)
 
         # batched H
         psi_save, exp_save = run_sesolve(system.H_batched, system.psi0)
-        assert psi_save.shape == (b_H, nt, n, 1)
-        assert exp_save.shape == (b_H, n_exp_ops, nt)
+        assert psi_save.shape == (b_H, num_t_save, n, 1)
+        assert exp_save.shape == (b_H, n_exp_ops, num_t_save)
 
         # batched psi0
         psi_save, exp_save = run_sesolve(system.H, system.psi0_batched)
-        assert psi_save.shape == (b_psi0, nt, n, 1)
-        assert exp_save.shape == (b_psi0, n_exp_ops, nt)
+        assert psi_save.shape == (b_psi0, num_t_save, n, 1)
+        assert exp_save.shape == (b_psi0, n_exp_ops, num_t_save)
 
         # batched H and psi0
         psi_save, exp_save = run_sesolve(system.H_batched, system.psi0_batched)
-        assert psi_save.shape == (b_H, b_psi0, nt, n, 1)
-        assert exp_save.shape == (b_H, b_psi0, n_exp_ops, nt)
+        assert psi_save.shape == (b_H, b_psi0, num_t_save, n, 1)
+        assert exp_save.shape == (b_H, b_psi0, n_exp_ops, num_t_save)
 
     def test_batching(self):
         pass
@@ -52,11 +52,11 @@ class SESolverTest:
         solver: SolverOption,
         system: ClosedSystem,
         *,
-        nt: int,
+        num_t_save: int,
         rtol: float = 1e-05,
         atol: float = 1e-08,
     ):
-        t_save = system.t_save(nt)
+        t_save = system.t_save(num_t_save)
 
         psi_save, _ = tq.sesolve(
             system.H,

--- a/tests/sesolve/sesolver_test.py
+++ b/tests/sesolve/sesolver_test.py
@@ -53,8 +53,7 @@ class SESolverTest:
         system: ClosedSystem,
         *,
         num_t_save: int,
-        rtol: float = 1e-05,
-        atol: float = 1e-08,
+        norm_atol: float = 1e-3,
     ):
         t_save = system.t_save(num_t_save)
 
@@ -66,7 +65,7 @@ class SESolverTest:
             solver=solver,
         )
 
-        assert torch.allclose(psi_save, system.psis(t_save), rtol=rtol, atol=atol)
+        assert torch.norm(psi_save - system.psis(t_save)) <= norm_atol
 
     def test_psi_save(self):
         pass

--- a/tests/sesolve/sesolver_test.py
+++ b/tests/sesolve/sesolver_test.py
@@ -1,0 +1,72 @@
+import torch
+
+import torchqdynamics as tq
+from torchqdynamics.solver_options import SolverOption
+
+from .closed_system import ClosedSystem
+
+
+class SESolverTest:
+    def _test_batching(self, solver: SolverOption, system: ClosedSystem):
+        """Test the batching of `H` and `psi0` in `sesolve`, and the returned object
+        sizes."""
+        n = system.n
+        n_exp_ops = len(system.exp_ops)
+        b_H = len(system.H_batched)
+        b_psi0 = len(system.psi0_batched)
+        nt = 11
+
+        run_mesolve = lambda H, psi0: tq.sesolve(
+            H,
+            psi0,
+            system.t_save(nt),
+            exp_ops=system.exp_ops,
+            solver=solver,
+        )
+
+        # no batching
+        psi_save, exp_save = run_mesolve(system.H, system.psi0)
+        assert psi_save.shape == (nt, n, 1)
+        assert exp_save.shape == (n_exp_ops, nt)
+
+        # batched H
+        psi_save, exp_save = run_mesolve(system.H_batched, system.psi0)
+        assert psi_save.shape == (b_H, nt, n, 1)
+        assert exp_save.shape == (b_H, n_exp_ops, nt)
+
+        # batched psi0
+        psi_save, exp_save = run_mesolve(system.H, system.psi0_batched)
+        assert psi_save.shape == (b_psi0, nt, n, 1)
+        assert exp_save.shape == (b_psi0, n_exp_ops, nt)
+
+        # batched H and psi0
+        psi_save, exp_save = run_mesolve(system.H_batched, system.psi0_batched)
+        assert psi_save.shape == (b_H, b_psi0, nt, n, 1)
+        assert exp_save.shape == (b_H, b_psi0, n_exp_ops, nt)
+
+    def test_batching(self):
+        pass
+
+    def _test_psi_save(
+        self,
+        solver: SolverOption,
+        system: ClosedSystem,
+        *,
+        nt: int,
+        rtol: float = 1e-05,
+        atol: float = 1e-08,
+    ):
+        t_save = system.t_save(nt)
+
+        psi_save, _ = tq.sesolve(
+            system.H,
+            system.psi0,
+            t_save,
+            exp_ops=system.exp_ops,
+            solver=solver,
+        )
+
+        assert torch.allclose(psi_save, system.psis(t_save), rtol=rtol, atol=atol)
+
+    def test_psi_save(self):
+        pass

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -11,8 +11,7 @@ class TestSEEuler(SESolverTest):
         solver = tq.solver.Euler(dt=1e-2)
         self._test_batching(solver, cavity_8)
 
-    @pytest.mark.skip(reason='failing - to fix')
     @pytest.mark.long
     def test_psi_save(self):
-        solver = tq.solver.Euler(dt=1e-4)
-        self._test_psi_save(solver, cavity_8, nt=51, rtol=1e-3, atol=1e-3)
+        solver = tq.solver.Euler(dt=1e-5)
+        self._test_psi_save(solver, cavity_8, nt=51, rtol=1e-2)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -1,9 +1,12 @@
+import numpy as np
 import pytest
 
 import torchqdynamics as tq
 
-from .closed_system import cavity_8
+from .closed_system import Cavity
 from .sesolver_test import SESolverTest
+
+cavity_8 = Cavity(n=8, delta=2 * np.pi, alpha0=1.0)
 
 
 class TestSEEuler(SESolverTest):

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -1,30 +1,18 @@
-import numpy as np
-import qutip as qt
+import pytest
 
 import torchqdynamics as tq
 
+from .closed_system import cavity_8
+from .sesolver_test import SESolverTest
 
-def test_sesolve_euler_cheap():
-    """Cheap test of the Euler method of sesolve."""
-    # parameters
-    n = 8
-    delta = 2 * np.pi
-    alpha0 = 1.0
 
-    # operators
-    a = qt.destroy(n)
-    adag = a.dag()
-    H = delta * adag * a
-    exp_ops = [(a + adag) / np.sqrt(2), (a - adag) / (np.sqrt(2) * 1j)]
-    num_exp_ops = len(exp_ops)
+class TestSEEuler(SESolverTest):
+    def test_batching(self):
+        solver = tq.solver.Euler(dt=1e-2)
+        self._test_batching(solver, cavity_8)
 
-    # other arguments
-    rho0 = qt.coherent(n, alpha0)
-    num_t_save = 51
-    t_save = np.linspace(0.0, delta / (2 * np.pi), num_t_save)  # a full tour
-    solver = tq.solver.Euler(dt=1e-3)
-
-    # run solver
-    states, exp = tq.sesolve(H, rho0, t_save, exp_ops=exp_ops, solver=solver)
-    assert states.shape == (num_t_save, n, 1)
-    assert exp.shape == (num_exp_ops, num_t_save)
+    @pytest.mark.skip(reason='failing - to fix')
+    @pytest.mark.long
+    def test_psi_save(self):
+        solver = tq.solver.Euler(dt=1e-4)
+        self._test_psi_save(solver, cavity_8, nt=51, rtol=1e-3, atol=1e-3)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -14,4 +14,4 @@ class TestSEEuler(SESolverTest):
     @pytest.mark.long
     def test_psi_save(self):
         solver = tq.solver.Euler(dt=1e-5)
-        self._test_psi_save(solver, cavity_8, nt=51, rtol=1e-2)
+        self._test_psi_save(solver, cavity_8, num_t_save=51, rtol=1e-2)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 import torchqdynamics as tq
 
@@ -14,7 +13,6 @@ class TestSEEuler(SESolverTest):
         solver = tq.solver.Euler(dt=1e-2)
         self._test_batching(solver, cavity_8)
 
-    @pytest.mark.long
     def test_psi_save(self):
-        solver = tq.solver.Euler(dt=1e-5)
-        self._test_psi_save(solver, cavity_8, num_t_save=51, rtol=1e-2)
+        solver = tq.solver.Euler(dt=1e-4)
+        self._test_psi_save(solver, cavity_8, num_t_save=11, norm_atol=1e-1)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -15,4 +15,4 @@ class TestSEEuler(SESolverTest):
 
     def test_psi_save(self):
         solver = tq.solver.Euler(dt=1e-4)
-        self._test_psi_save(solver, cavity_8, num_t_save=11, norm_atol=1e-1)
+        self._test_psi_save(solver, cavity_8, num_t_save=11)


### PR DESCRIPTION
Here's what I had in mind for the test framework, it may look like a big PR but it's not, a lot of the code is really straightforward/similar to read. I suggest reading `testssesolve/closed_system.py`, then `tests/sesolve/sesolver_test.py`, then `tests/sesolve/test_euler.py` to understand the logic, then the rest.

The proposal is to decouple the physical systems from the tested solvers. So we would have
- A few physical systems defining `H`, `jump_ops`, etc... (a qubit, a cavity, two coupled systems)
- Base test classes for the solver with helper methods.
- A test class for each solver that picks the relevant physical system to test something (e.g. batching, computed states correctness, stability, etc...).

I think what's important is that everything is optional: you can define a physical system with no analytical solution (but then you can't use it to check computed states correctness, obviously), you can test batching only for a specific solver, etc... Another important aspect is that we can here separate long-running tests that we will probably not run for each PR (for example checking a solver solution for long-time evolution) from quick tests that are just checking the logic.

And then I think we can use the physical systems to implement benchmarks between solvers (to monitor performance when a PR modifies the solvers code or the odeint code). I don't think we need this for now, but in a few months ~when a random guy from Patagonia makes a PR to propose some dark magic torch optimization~, it will be nice to have.