### PR TITLE
Add isort configuration to ignore files in `.gitignore`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ packages = ["torchqdynamics"]
 [tool.isort]
 profile = "black"
 skip = ["__init__.py"]
+skip_gitignore = true
 
 [tool.black]
 preview = true


### PR DESCRIPTION
Note that this is done automatically by black (https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore).