### PR TITLE
Fix `dtype` and `device` throughout the code

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,8 +21,8 @@ def test_ket_fidelity_batching():
     b1, b2, n = 3, 5, 8
     psi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, 1)
     phi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, 1)
-    psi = tq.tensor_types.to_tensor(psi)
-    phi = tq.tensor_types.to_tensor(phi)
+    psi = tq.to_tensor(psi)
+    phi = tq.to_tensor(phi)
     assert tq.ket_fidelity(psi, phi).shape == (b1, b2)
 
 
@@ -43,6 +43,6 @@ def test_dm_fidelity_batching():
     b1, b2, n = 3, 5, 8
     rho = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
     sigma = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
-    rho = tq.tensor_types.to_tensor(rho)
-    sigma = tq.tensor_types.to_tensor(sigma)
+    rho = tq.to_tensor(rho)
+    sigma = tq.to_tensor(sigma)
     assert tq.dm_fidelity(rho, sigma).shape == (b1, b2)

--- a/torchqdynamics/__init__.py
+++ b/torchqdynamics/__init__.py
@@ -4,4 +4,5 @@ from .sesolve import sesolve
 from .smesolve import smesolve
 from .solver import *
 from .states import *
+from .tensor_types import *
 from .utils import *

--- a/torchqdynamics/adaptive.py
+++ b/torchqdynamics/adaptive.py
@@ -27,9 +27,6 @@ class AdaptiveSolver(ABC):
         max_factor: float = 5.0,
         atol: float = 1e-8,
         rtol: float = 1e-6,
-        t_dtype: torch.dtype = torch.float64,
-        y_dtype: torch.dtype = torch.complex128,
-        device: torch.device | None = None,
     ):
         self.f = f
         self.factor = factor
@@ -37,14 +34,11 @@ class AdaptiveSolver(ABC):
         self.max_factor = max_factor
         self.atol = atol
         self.rtol = rtol
-        self.t_dtype = t_dtype
-        self.y_dtype = y_dtype
-        self.device = device
         self.order = None
         self.tableau = None
 
     @abstractmethod
-    def build_tableau(self):
+    def build_tableau(self, target: Tensor):
         """Build the Butcher tableau of the integrator."""
         pass
 

--- a/torchqdynamics/adaptive.py
+++ b/torchqdynamics/adaptive.py
@@ -5,9 +5,9 @@ from typing import Callable
 
 import torch
 from torch import Tensor
-from torch._prims_common import corresponding_real_dtype as to_float
 
 from .solver_utils import hairer_norm
+from .tensor_types import dtype_complex_to_float
 
 
 class AdaptiveSolver(ABC):
@@ -142,11 +142,11 @@ class DormandPrince45(AdaptiveSolver):
 
         # extract target information
         dtype = target.dtype
-        real_dtype = to_float(dtype)
+        float_dtype = dtype_complex_to_float(dtype)
         device = target.device
 
         # initialize tensors
-        alpha = torch.tensor(alpha, dtype=real_dtype, device=device)
+        alpha = torch.tensor(alpha, dtype=float_dtype, device=device)
         beta = torch.tensor(beta, dtype=dtype, device=device)
         csol5 = torch.tensor(csol5, dtype=dtype, device=device)
         csol4 = torch.tensor(csol4, dtype=dtype, device=device)

--- a/torchqdynamics/mesolve/mesolve.py
+++ b/torchqdynamics/mesolve/mesolve.py
@@ -27,6 +27,8 @@ def mesolve(
     solver: SolverOption | None = None,
     gradient_alg: Literal['autograd', 'adjoint'] | None = None,
     parameters: tuple[nn.Parameter, ...] | None = None,
+    dtype: torch.complex64 | torch.complex128 | None = None,
+    device: torch.device | None = None,
 ) -> tuple[Tensor, Tensor]:
     """Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
 
@@ -73,6 +75,10 @@ def mesolve(
             backward pass. Defaults to `None`.
         parameters (tuple of nn.Parameter): Parameters with respect to which gradients
             are computed during the adjoint state backward pass.
+        dtype (torch.dtype, optional): Data type of the complex tensors (i.e. all
+            arguments but `t_save`, whose type is inferred from the underlying data
+            type).
+        device (torch.device, optional): Device on which the tensors are stored.
 
     Returns:
         A tuple `(rho_save, exp_save)` where
@@ -87,7 +93,7 @@ def mesolve(
     # TODO H is assumed to be time-independent from here (temporary)
 
     # convert H to a tensor and batch by default
-    H = to_tensor(H)
+    H = to_tensor(H, dtype=dtype, device=device, is_complex=True)
     H_batched = H[None, ...] if H.ndim == 2 else H
 
     # convert jump_ops to a tensor
@@ -96,11 +102,11 @@ def mesolve(
             'Argument `jump_ops` must be a non-empty list of tensors. Otherwise,'
             ' consider using `sesolve`.'
         )
-    jump_ops = to_tensor(jump_ops)
+    jump_ops = to_tensor(jump_ops, dtype=dtype, device=device, is_complex=True)
     jump_ops = jump_ops[None, ...] if jump_ops.ndim == 2 else jump_ops
 
     # convert rho0 to a tensor and density matrix and batch by default
-    rho0 = to_tensor(rho0)
+    rho0 = to_tensor(rho0, dtype=dtype, device=device, is_complex=True)
     if is_ket(rho0):
         rho0 = ket_to_dm(rho0)
     b_H = H_batched.size(0)
@@ -108,10 +114,10 @@ def mesolve(
     rho0_batched = rho0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_rho0, n, n)
 
     # convert t_save to a tensor
-    t_save = torch.as_tensor(t_save)
+    t_save = torch.as_tensor(t_save, device=device)
 
     # convert exp_ops to a tensor
-    exp_ops = to_tensor(exp_ops)
+    exp_ops = to_tensor(exp_ops, dtype=dtype, device=device, is_complex=True)
     exp_ops = exp_ops[None, ...] if exp_ops.ndim == 2 else exp_ops
 
     # default solver

--- a/torchqdynamics/mesolve/mesolve.py
+++ b/torchqdynamics/mesolve/mesolve.py
@@ -8,7 +8,13 @@ from torch import Tensor
 
 from ..odeint import odeint
 from ..solver_options import AdaptiveStep, Dopri45, Euler, SolverOption
-from ..tensor_types import OperatorLike, TDOperatorLike, TensorLike, to_tensor
+from ..tensor_types import (
+    OperatorLike,
+    TDOperatorLike,
+    TensorLike,
+    dtype_complex_to_float,
+    to_tensor,
+)
 from ..utils import is_ket, ket_to_dm
 from .adaptive import MEAdaptive
 from .euler import MEEuler
@@ -75,9 +81,9 @@ def mesolve(
             backward pass. Defaults to `None`.
         parameters (tuple of nn.Parameter): Parameters with respect to which gradients
             are computed during the adjoint state backward pass.
-        dtype (torch.dtype, optional): Data type of the complex tensors (i.e. all
-            arguments but `t_save`, whose type is inferred from the underlying data
-            type).
+        dtype (torch.dtype, optional): Complex data type to which all complex-valued
+            tensors are converted. `t_save` is also converted to a real data type of
+            the corresponding precision.
         device (torch.device, optional): Device on which the tensors are stored.
 
     Returns:
@@ -114,7 +120,7 @@ def mesolve(
     rho0_batched = rho0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_rho0, n, n)
 
     # convert t_save to a tensor
-    t_save = torch.as_tensor(t_save, device=device)
+    t_save = torch.as_tensor(t_save, dtype=dtype_complex_to_float(dtype), device=device)
 
     # convert exp_ops to a tensor
     exp_ops = to_tensor(exp_ops, dtype=dtype, device=device, is_complex=True)

--- a/torchqdynamics/odeint.py
+++ b/torchqdynamics/odeint.py
@@ -144,10 +144,14 @@ def _adaptive_odeint(
     y_save, exp_save = None, None
     batch_sizes, (m, n) = y0.shape[:-2], y0.shape[-2:]
     if save_states:
-        y_save = torch.zeros(*batch_sizes, len(t_save), m, n).to(y0)
+        y_save = torch.zeros(
+            *batch_sizes, len(t_save), m, n, dtype=y0.dtype, device=y0.device
+        )
 
     if len(exp_ops) > 0:
-        exp_save = torch.zeros(*batch_sizes, len(exp_ops), len(t_save)).to(y0)
+        exp_save = torch.zeros(
+            *batch_sizes, len(exp_ops), len(t_save), dtype=y0.dtype, device=y0.device
+        )
 
     # save initial solution
     save_counter = 0
@@ -167,9 +171,6 @@ def _adaptive_odeint(
         qsolver.options.max_factor,
         qsolver.options.atol,
         qsolver.options.rtol,
-        t_save.dtype,
-        y0.dtype,
-        y0.device,
     )
     if isinstance(qsolver.options, Dopri45):
         solver = DormandPrince45(*args)
@@ -227,7 +228,9 @@ def _adaptive_odeint(
         y_save = y
 
     if len(exp_ops) == 0:
-        exp_save = torch.empty(*batch_sizes, len(exp_ops))
+        exp_save = torch.empty(
+            *batch_sizes, len(exp_ops), dtype=y0.dtype, device=y0.device
+        )
 
     return y_save, exp_save
 
@@ -274,10 +277,14 @@ def _fixed_odeint(
     y_save, exp_save = None, None
     batch_sizes, (m, n) = y0.shape[:-2], y0.shape[-2:]
     if save_states:
-        y_save = torch.zeros(*batch_sizes, len(t_save), m, n).to(y0)
+        y_save = torch.zeros(
+            *batch_sizes, len(t_save), m, n, dtype=y0.dtype, device=y0.device
+        )
 
     if len(exp_ops) > 0:
-        exp_save = torch.zeros(*batch_sizes, len(exp_ops), len(t_save)).to(y0)
+        exp_save = torch.zeros(
+            *batch_sizes, len(exp_ops), len(t_save), dtype=y0.dtype, device=y0.device
+        )
 
     # define time values
     num_times = torch.round(t_save[-1] / dt).int() + 1
@@ -307,7 +314,9 @@ def _fixed_odeint(
     if len(exp_ops) > 0:
         exp_save[..., save_counter] = bexpect(exp_ops, y)
     else:
-        exp_save = torch.empty(*batch_sizes, len(exp_ops))
+        exp_save = torch.empty(
+            *batch_sizes, len(exp_ops), dtype=y0.dtype, device=y0.device
+        )
 
     return y_save, exp_save
 

--- a/torchqdynamics/operators.py
+++ b/torchqdynamics/operators.py
@@ -5,6 +5,7 @@ from math import prod
 import torch
 from torch import Tensor
 
+from .tensor_types import complex_tensor
 from .utils import tensprod
 
 __all__ = [
@@ -21,54 +22,45 @@ __all__ = [
 ]
 
 
-def sigmax(
-    *, dtype: torch.dtype = torch.complex128, device: torch.device | None = None
-) -> Tensor:
+@complex_tensor
+def sigmax(*, dtype=None, device=None) -> Tensor:
     """Pauli $X$ operator."""
     return torch.tensor([[0.0, 1.0], [1.0, 0.0]], dtype=dtype, device=device)
 
 
-def sigmay(
-    *, dtype: torch.dtype = torch.complex128, device: torch.device | None = None
-) -> Tensor:
+@complex_tensor
+def sigmay(*, dtype=None, device=None) -> Tensor:
     """Pauli $Y$ operator."""
     return torch.tensor([[0.0, -1.0j], [1.0j, 0.0]], dtype=dtype, device=device)
 
 
-def sigmaz(
-    *, dtype: torch.dtype = torch.complex128, device: torch.device | None = None
-) -> Tensor:
+@complex_tensor
+def sigmaz(*, dtype=None, device=None) -> Tensor:
     """Pauli $Z$ operator."""
     return torch.tensor([[1.0, 0.0], [0.0, -1.0]], dtype=dtype, device=device)
 
 
-def sigmap(
-    *, dtype: torch.dtype = torch.complex128, device: torch.device | None = None
-) -> Tensor:
+@complex_tensor
+def sigmap(*, dtype=None, device=None) -> Tensor:
     r"""Pauli raising operator $\sigma_+$."""
     return torch.tensor([[0.0, 1.0], [0.0, 0.0]], dtype=dtype, device=device)
 
 
-def sigmam(
-    *, dtype: torch.dtype = torch.complex128, device: torch.device | None = None
-) -> Tensor:
+@complex_tensor
+def sigmam(*, dtype=None, device=None) -> Tensor:
     r"""Pauli lowering operator $\sigma_-$."""
     return torch.tensor([[0.0, 0.0], [1.0, 0.0]], dtype=dtype, device=device)
 
 
-def eye(
-    *dims: int,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device | None = None,
-) -> Tensor:
+@complex_tensor
+def eye(*dims: int, dtype=None, device=None) -> Tensor:
     """Identity operator."""
     dim = prod(dims)
     return torch.eye(dim, dtype=dtype, device=device)
 
 
-def destroy(
-    *dims: int, dtype: torch.dtype = torch.complex128, device: torch.device = None
-) -> Tensor | tuple[Tensor, ...]:
+@complex_tensor
+def destroy(*dims: int, dtype=None, device=None) -> Tensor | tuple[Tensor, ...]:
     """Bosonic annihilation operator.
 
     If only a single dimension is provided, `destroy` returns the annihilation operator
@@ -112,21 +104,14 @@ def destroy(
     )
 
 
-def _destroy_single(
-    dim: int,
-    *,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device | None = None,
-) -> Tensor:
+@complex_tensor
+def _destroy_single(dim: int, *, dtype=None, device=None) -> Tensor:
     """Bosonic annihilation operator."""
     return torch.arange(1, dim, device=device).sqrt().diag(1).to(dtype)
 
 
-def create(
-    *dims: int,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device | None = None,
-) -> Tensor | tuple[Tensor, ...]:
+@complex_tensor
+def create(*dims: int, dtype=None, device=None) -> Tensor | tuple[Tensor, ...]:
     """Bosonic creation operator.
 
     If only a single dimension is provided, `create` returns the creation operator of
@@ -170,35 +155,21 @@ def create(
     )
 
 
-def _create_single(
-    dim: int,
-    *,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device | None = None,
-) -> Tensor:
+@complex_tensor
+def _create_single(dim: int, *, dtype=None, device=None) -> Tensor:
     """Bosonic creation operator."""
     return torch.arange(1, dim, device=device).sqrt().diag(-1).to(dtype)
 
 
-def displace(
-    dim: int,
-    alpha: complex,
-    *,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device | None = None,
-) -> Tensor:
+@complex_tensor
+def displace(dim: int, alpha: complex, *, dtype=None, device=None) -> Tensor:
     """Displacement operator."""
     a = destroy(dim, dtype=dtype, device=device)
     return torch.matrix_exp(alpha * a.adjoint() - alpha.conjugate() * a)
 
 
-def squeeze(
-    dim: int,
-    z: complex,
-    *,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device | None = None,
-) -> Tensor:
+@complex_tensor
+def squeeze(dim: int, z: complex, *, dtype=None, device=None) -> Tensor:
     """Squeezing operator."""
     a = destroy(dim, dtype=dtype, device=device)
     a2 = a @ a

--- a/torchqdynamics/sesolve/sesolve.py
+++ b/torchqdynamics/sesolve/sesolve.py
@@ -23,6 +23,8 @@ def sesolve(
     solver: SolverOption | None = None,
     gradient_alg: Literal['autograd', 'adjoint'] | None = None,
     parameters: tuple[nn.Parameter, ...] | None = None,
+    dtype: torch.complex64 | torch.complex128 | None = None,
+    device: torch.device | None = None,
 ) -> tuple[Tensor, Tensor]:
     # Args:
     #     H: (b_H?, n, n)
@@ -37,13 +39,13 @@ def sesolve(
     # TODO H is assumed to be time-independent from here (temporary)
 
     # convert H to a tensor and batch by default
-    H = to_tensor(H)
+    H = to_tensor(H, dtype=dtype, device=device, is_complex=True)
     H_batched = H[None, ...] if H.ndim == 2 else H
 
     # convert psi0 to a tensor and batch by default
     # TODO add test to check that psi0 has the correct shape
     b_H = H_batched.size(0)
-    psi0 = to_tensor(psi0)
+    psi0 = to_tensor(psi0, dtype=dtype, device=device, is_complex=True)
     psi0_batched = psi0[None, ...] if psi0.ndim == 2 else psi0
     psi0_batched = psi0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_psi0, n, 1)
 
@@ -51,7 +53,7 @@ def sesolve(
     t_save = torch.as_tensor(t_save)
 
     # convert exp_ops to tensor
-    exp_ops = to_tensor(exp_ops)
+    exp_ops = to_tensor(exp_ops, dtype=dtype, device=device, is_complex=True)
     exp_ops = exp_ops[None, ...] if exp_ops.ndim == 2 else exp_ops
 
     # default solver

--- a/torchqdynamics/sesolve/sesolve.py
+++ b/torchqdynamics/sesolve/sesolve.py
@@ -8,7 +8,13 @@ from torch import Tensor
 
 from ..odeint import odeint
 from ..solver_options import AdaptiveStep, Dopri45, Euler, SolverOption
-from ..tensor_types import OperatorLike, TDOperatorLike, TensorLike, to_tensor
+from ..tensor_types import (
+    OperatorLike,
+    TDOperatorLike,
+    TensorLike,
+    dtype_complex_to_float,
+    to_tensor,
+)
 from .adaptive import SEAdaptive
 from .euler import SEEuler
 
@@ -50,7 +56,7 @@ def sesolve(
     psi0_batched = psi0_batched[None, ...].repeat(b_H, 1, 1, 1)  # (b_H, b_psi0, n, 1)
 
     # convert t_save to tensor
-    t_save = torch.as_tensor(t_save)
+    t_save = torch.as_tensor(t_save, dtype=dtype_complex_to_float(dtype), device=device)
 
     # convert exp_ops to tensor
     exp_ops = to_tensor(exp_ops, dtype=dtype, device=device, is_complex=True)

--- a/torchqdynamics/states.py
+++ b/torchqdynamics/states.py
@@ -6,17 +6,19 @@ import torch
 from torch import Tensor
 
 from .operators import displace
+from .tensor_types import complex_tensor
 from .utils import ket_to_dm
 
 __all__ = ['fock', 'fock_dm', 'coherent', 'coherent_dm']
 
 
+@complex_tensor
 def fock(
     dims: int | tuple[int, ...],
     states: int | tuple[int, ...],
     *,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device = None,
+    dtype=None,
+    device=None,
 ) -> Tensor:
     """State vector of a Fock state, or of a tensor product of Fock states.
 
@@ -51,12 +53,13 @@ def fock(
     return ket
 
 
+@complex_tensor
 def fock_dm(
     dims: int | tuple[int, ...],
     states: int | tuple[int, ...],
     *,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device = None,
+    dtype=None,
+    device=None,
 ) -> Tensor:
     """Density matrix of a Fock state, or of a tensor product of Fock states.
 
@@ -77,13 +80,8 @@ def fock_dm(
     return ket_to_dm(fock(dims, states, dtype=dtype, device=device))
 
 
-def coherent(
-    dim: int,
-    alpha: complex,
-    *,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device = None,
-) -> Tensor:
+@complex_tensor
+def coherent(dim: int, alpha: complex, *, dtype=None, device=None) -> Tensor:
     """State vector of a coherent state.
 
     Example:
@@ -97,13 +95,8 @@ def coherent(
     return displace(dim, alpha, dtype=dtype, device=device) @ fock(dim, 0)
 
 
-def coherent_dm(
-    dim: int,
-    alpha: complex,
-    *,
-    dtype: torch.dtype = torch.complex128,
-    device: torch.device = None,
-) -> Tensor:
+@complex_tensor
+def coherent_dm(dim: int, alpha: complex, *, dtype=None, device=None) -> Tensor:
     """Density matrix of a coherent state.
 
     Example:

--- a/torchqdynamics/tensor_types.py
+++ b/torchqdynamics/tensor_types.py
@@ -99,6 +99,13 @@ def complex_tensor(func):
     return wrapper
 
 
+def dtype_complex_to_float(
+    dtype: torch.complex64 | torch.complex128 | None = None,
+) -> torch.float32 | torch.float64:
+    dtype = cdtype(dtype)
+    return torch.float64 if dtype is torch.complex128 else torch.float32
+
+
 @complex_tensor
 def from_qutip(x: Qobj, *, dtype=None, device=None) -> Tensor:
     """Convert a QuTiP quantum object to a PyTorch tensor.

--- a/torchqdynamics/tensor_types.py
+++ b/torchqdynamics/tensor_types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 from typing import Callable, Union, get_args
 
 import numpy as np
@@ -7,7 +8,11 @@ import torch
 from qutip import Qobj
 from torch import Tensor
 
-from .utils import from_qutip
+__all__ = [
+    'to_tensor',
+    'from_qutip',
+    'to_qutip',
+]
 
 # TODO add typing for Hamiltonian with piecewise-constant factor
 TDOperator = Union[Tensor, Callable[[float], Tensor]]
@@ -22,30 +27,99 @@ OperatorLike = Union[TensorLike, Qobj]
 TDOperatorLike = Union[OperatorLike, Callable[[float], OperatorLike]]
 
 
-def to_tensor(x: OperatorLike | list[OperatorLike] | None) -> Tensor:
+def to_tensor(
+    x: OperatorLike | list[OperatorLike] | None,
+    *,
+    dtype: torch.dtype | None = None,
+    device: torch.device | None = None,
+    is_complex: bool = False,
+) -> Tensor:
     """Convert a `OperatorLike` object or a list of `OperatorLike` object to a PyTorch
     tensor.
 
     Args:
         x: QuTiP quantum object or NumPy array or Python list or PyTorch tensor or list
            of these types. If `None` or empty list, returns an empty tensor of size (0).
+        dtype: Data type of the returned tensor.
+        device: Device on which the returned tensor is stored.
 
     Returns:
         PyTorch tensor.
     """
+    if is_complex:
+        dtype = cdtype(dtype)
+
     if x is None:
-        return torch.tensor([])
+        return torch.tensor([], dtype=dtype, device=device)
     if isinstance(x, list):
         if len(x) == 0:
-            return torch.tensor([])
-        return torch.stack([to_tensor(y) for y in x])
+            return torch.tensor([], dtype=dtype, device=device)
+        return torch.stack([to_tensor(y, dtype=dtype, device=device) for y in x])
     if isinstance(x, Qobj):
-        return from_qutip(x)
+        return from_qutip(x, dtype=dtype, device=device)
     elif isinstance(x, get_args(TensorLike)):
-        return torch.as_tensor(x)
+        return torch.as_tensor(x, dtype=dtype, device=device)
     else:
         raise TypeError(
             f'Input of type {type(x)} is not supported. `to_tensor` only '
             'supports QuTiP quantum object, NumPy array, Python list or PyTorch tensor '
             'or list of these types.'
         )
+
+
+def cdtype(
+    dtype: torch.complex64 | torch.complex128 | None = None,
+) -> torch.complex64 | torch.complex128:
+    if dtype is None:
+        # the default dtype for complex tensors is determined by the default
+        # floating point dtype (torch.complex128 if default is torch.float64,
+        # otherwise torch.complex64)
+        if torch.get_default_dtype() is torch.float64:
+            return torch.complex128
+        else:
+            return torch.complex64
+    elif dtype not in (torch.complex64, torch.complex128):
+        raise TypeError(
+            f'Argument `dtype` ({dtype}) must be `torch.complex64`,'
+            ' `torch.complex128` or `None` for a complex tensor.'
+        )
+    return dtype
+
+
+def complex_tensor(func):
+    @functools.wraps(func)
+    def wrapper(
+        *args,
+        dtype: torch.complex64 | torch.complex128 | None = None,
+        device: torch.device | None = None,
+        **kwargs,
+    ):
+        return func(*args, dtype=cdtype(dtype), device=device, **kwargs)
+
+    return wrapper
+
+
+@complex_tensor
+def from_qutip(x: Qobj, *, dtype=None, device=None) -> Tensor:
+    """Convert a QuTiP quantum object to a PyTorch tensor.
+
+    Args:
+        x: QuTiP quantum object.
+
+    Returns:
+        PyTorch tensor.
+    """
+    return torch.from_numpy(x.full()).to(dtype=dtype, device=device)
+
+
+def to_qutip(x: Tensor, dims: list | None = None) -> Qobj:
+    """Convert a PyTorch tensor to a QuTiP quantum object.
+
+    Args:
+        x: PyTorch tensor.
+        dims: QuTiP object dimensions.
+
+    Returns:
+        QuTiP quantum object.
+    """
+    return Qobj(x.numpy(force=True), dims=dims)


### PR DESCRIPTION
Written on top of #63. This PR fixes the creation of tensors to rigorously handle `dtype` and `device`. Basically, we must use `dtype` and `device` anywhere we create a tensor, whether it's being directly built or converted from another data type. The `dtype`/`device` is either set by the context (e.g. it has the same type as another tensor) or from arguments passed to the function/class creating the tensor.

- I removed the typing of `dtype` and `device` for objects decorated by `@complex_tensor`, mainly to ease readability (and because static type checking should work through the decorator).
- @gautierronan do we also need the `dtype`/`device` for the `none_to_zeros_like` function? I would say yes.
- I checked that the typing propagates correctly through `mesolve` and `sesolve` (i.e. the returned objects have the correct type, and we can set it independently of the default type).
- We should also fix the creation of tensors in the tests, but I'll do it in an incoming PR where we switch from QuTiP functions to ours.