### PR TITLE
Begin restructuring `Solver` class

### DIFF
--- a/torchqdynamics/ode/adjoint_solver.py
+++ b/torchqdynamics/ode/adjoint_solver.py
@@ -135,7 +135,7 @@ class ODEIntAdjoint(torch.autograd.Function):
         ctx.t_save = solver.t_save if solver.options.save_states else solver.t_save[-1]
 
         # integrate the ODE forward without storing the graph of operations
-        solver._odeint_inplace()
+        solver.odeint_inplace()
 
         # save results and model parameters
         ctx.save_for_backward(solver.y_save)

--- a/torchqdynamics/ode/forward_solver.py
+++ b/torchqdynamics/ode/forward_solver.py
@@ -54,6 +54,10 @@ class ForwardSolver(Solver):
                 ' multiple of the time step `dt`.'
             )
 
+        # initialize the progress bar
+        tot_num_times = torch.round(self.t_save[-1] / dt).int() + 1
+        pbar = tqdm(total=tot_num_times, disable=not self.options.verbose)
+
         # run the ode routine
         t0, y = 0.0, self.y0
         for i, ti in enumerate(self.t_save):
@@ -64,6 +68,7 @@ class ForwardSolver(Solver):
             # iterate to ti
             for t in times[:-1]:
                 y = self.forward(t, y)
+                pbar.update(1)
 
             # save
             t0 = ti

--- a/torchqdynamics/ode/forward_solver.py
+++ b/torchqdynamics/ode/forward_solver.py
@@ -60,18 +60,18 @@ class ForwardSolver(Solver):
 
         # run the ode routine
         t0, y = 0.0, self.y0
-        for i, ti in enumerate(self.t_save):
+        for i, t1 in enumerate(self.t_save):
             # define time values
-            num_times = torch.round((ti - t0) / dt).int() + 1
-            times = torch.linspace(t0, ti, num_times)
+            num_times = torch.round((t1 - t0) / dt).int() + 1
+            times = torch.linspace(t0, t1, num_times)
 
-            # iterate to ti
+            # iterate to t1
             for t in times[:-1]:
                 y = self.forward(t, y)
                 pbar.update(1)
 
             # save
-            t0 = ti
+            t0 = t1
             self.save(i, y)
 
     def _adaptive_odeint(self):
@@ -109,13 +109,13 @@ class ForwardSolver(Solver):
         # run the ODE routine
         t, y, ft = t0, self.y0, f0
         step_counter = 0
-        for i, ti in enumerate(self.t_save):
-            while t < ti:
+        for i, t1 in enumerate(self.t_save):
+            while t < t1:
                 # update time step
                 dt = integrator.update_tstep(dt, error)
-                if t + dt >= ti:
+                if t + dt >= t1:
                     cache = (dt, error)
-                    dt = ti - t
+                    dt = t1 - t
 
                 # perform a single ODE integrator step of size dt
                 ft_new, y_new, y_err = integrator.step(ft, y, t, dt)

--- a/torchqdynamics/ode/forward_solver.py
+++ b/torchqdynamics/ode/forward_solver.py
@@ -56,7 +56,7 @@ class ForwardSolver(Solver):
 
         # initialize the progress bar
         tot_num_times = torch.round(self.t_save[-1] / dt).int() + 1
-        pbar = tqdm(total=tot_num_times, disable=not self.options.verbose)
+        pbar = tqdm(total=tot_num_times.item(), disable=not self.options.verbose)
 
         # run the ode routine
         t0, y = 0.0, self.y0

--- a/torchqdynamics/sesolve/propagator.py
+++ b/torchqdynamics/sesolve/propagator.py
@@ -12,7 +12,7 @@ class SEPropagator(Solver):
 
     def odeint(self):
         y, t0 = self.y0, 0.0
-        for i, ti in enumerate(tqdm(self.t_save, disable=not self.options.verbose)):
-            y = torch.matrix_exp(-1j * self.H * (ti - t0)) @ y
-            t0 = ti
+        for i, t1 in enumerate(tqdm(self.t_save, disable=not self.options.verbose)):
+            y = torch.matrix_exp(-1j * self.H * (t1 - t0)) @ y
+            t0 = t1
             self.save(i, y)

--- a/torchqdynamics/sesolve/propagator.py
+++ b/torchqdynamics/sesolve/propagator.py
@@ -10,7 +10,7 @@ class SEPropagator(Solver):
 
         self.H = self.H[:, None, ...]  # (b_H, 1, n, n)
 
-    def run(self):
+    def odeint(self):
         y, t0 = self.y0, 0.0
         for i, ti in enumerate(tqdm(self.t_save, disable=not self.options.verbose)):
             y = torch.matrix_exp(-1j * self.H * (ti - t0)) @ y

--- a/torchqdynamics/sesolve/propagator.py
+++ b/torchqdynamics/sesolve/propagator.py
@@ -11,8 +11,8 @@ class SEPropagator(Solver):
         self.H = self.H[:, None, ...]  # (b_H, 1, n, n)
 
     def run(self):
-        y, t1 = self.y0, 0.0
-        for t2 in tqdm(self.t_save, disable=not self.options.verbose):
-            y = torch.matrix_exp(-1j * self.H * (t2 - t1)) @ y
-            t1 = t2
-            self.save(y)
+        y, t0 = self.y0, 0.0
+        for i, ti in enumerate(tqdm(self.t_save, disable=not self.options.verbose)):
+            y = torch.matrix_exp(-1j * self.H * (ti - t0)) @ y
+            t0 = ti
+            self.save(i, y)

--- a/torchqdynamics/solver.py
+++ b/torchqdynamics/solver.py
@@ -60,8 +60,6 @@ class Solver(ABC):
         self.gradient_alg = gradient_alg
         self.parameters = parameters
 
-        self.save_counter = 0
-
         # initialize save tensors
         batch_sizes, (m, n) = self.y0.shape[:-2], self.y0.shape[-2:]
 
@@ -92,21 +90,17 @@ class Solver(ABC):
     def run(self):
         pass
 
-    def next_tsave(self) -> float:
-        return self.t_save[self.save_counter]
+    def save(self, i: int, y: Tensor):
+        self._save_y(i, y)
+        self._save_exp_ops(i, y)
 
-    def save(self, y: Tensor):
-        self._save_y(y)
-        self._save_exp_ops(y)
-        self.save_counter += 1
-
-    def _save_y(self, y: Tensor):
+    def _save_y(self, i: int, y: Tensor):
         if self.options.save_states:
-            self.y_save[..., self.save_counter, :, :] = y
+            self.y_save[..., i, :, :] = y
         # otherwise only save the state if it is the final state
-        elif self.save_counter == len(self.t_save) - 1:
+        elif i == len(self.t_save) - 1:
             self.y_save = y
 
-    def _save_exp_ops(self, y: Tensor):
+    def _save_exp_ops(self, i: int, y: Tensor):
         if len(self.exp_ops) > 0:
-            self.exp_save[..., self.save_counter] = bexpect(self.exp_ops, y)
+            self.exp_save[..., i] = bexpect(self.exp_ops, y)

--- a/torchqdynamics/solver.py
+++ b/torchqdynamics/solver.py
@@ -86,8 +86,27 @@ class Solver(ABC):
         else:
             self.exp_save = None
 
-    @abstractmethod
     def run(self):
+        if self.gradient_alg is None:
+            self.odeint_inplace()
+        elif self.gradient_alg == 'autograd':
+            self.odeint()
+
+    def odeint_inplace(self):
+        """Integrate a quantum ODE with an in-place solver.
+
+        Simple solution for now so torch does not store gradients.
+        TODO Implement a genuine in-place integrator.
+        """
+        with torch.no_grad():
+            self.odeint()
+
+    @abstractmethod
+    def odeint(self):
+        """Integrate a quantum ODE starting from an initial state.
+
+        The ODE is solved from time `t=0.0` to `t=t_save[-1]`.
+        """
         pass
 
     def save(self, i: int, y: Tensor):


### PR DESCRIPTION
For the implementation of a fixed-time step Runge kutta solver, I need to restructure the `Solver` class. 

Also, the `Propagator` method was currently not dispatching between `self.gradient_alg = None` and `self.gradient_alg = "autograd"`. So I'm proposing a solution for these. 

This PR also removes all the unnecessary `save_flag` feature in `adaptive_odeint`, and the time checks in `fixed_odeint`. 